### PR TITLE
Fix compiler warnings in our limelight code

### DIFF
--- a/limelight/build.gradle
+++ b/limelight/build.gradle
@@ -2,6 +2,8 @@ plugins {
 	id 'java-library'
 	id "edu.wpi.first.GradleRIO" version "2025.1.1"
 	id 'idea'
+	// Spotless code formatter.
+	id 'com.diffplug.spotless' version '6.25.0'
 }
 
 idea {
@@ -38,4 +40,27 @@ wpi.java.configureTestTasks(test)
 tasks.named('test') {
 	// Use JUnit 4 for tests
 	useJUnit()
+}
+
+spotless {
+	// See https://github.com/diffplug/spotless/tree/main/plugin-gradle
+	format 'misc', {
+		// define the files to apply `misc` to
+		target '.gitattributes', '.gitignore'
+
+		// define the steps to apply to those files
+		trimTrailingWhitespace()
+		indentWithSpaces()
+		endWithNewline()
+	}
+	java {
+		// importOrder() // Use the default importOrder configuration (can override)
+		removeUnusedImports()
+
+		// Use Google Java Format
+		// - aosp() causes it to use a four-space indent
+		// googleJavaFormat('1.24.0').reflowLongStrings()
+
+		formatAnnotations()  // fix formatting of type annotations
+	}
 }

--- a/limelight/src/main/java/com/team2813/lib2813/limelight/JSONHelper.java
+++ b/limelight/src/main/java/com/team2813/lib2813/limelight/JSONHelper.java
@@ -1,8 +1,6 @@
 package com.team2813.lib2813.limelight;
 
 import java.util.Optional;
-import java.util.OptionalDouble;
-import java.util.OptionalLong;
 import java.util.function.Function;
 
 import org.json.JSONArray;

--- a/limelight/src/main/java/com/team2813/lib2813/limelight/Limelight.java
+++ b/limelight/src/main/java/com/team2813/lib2813/limelight/Limelight.java
@@ -11,7 +11,7 @@ public interface Limelight {
 	 * Gets the limelight with the default name.
 	 * @return the {@link Limelight} object for interfacing with the limelight
 	 */
-	public static Limelight getDefaultLimelight() {
+	static Limelight getDefaultLimelight() {
 		return RestLimelight.getDefaultLimelight();
 	}
 

--- a/limelight/src/main/java/com/team2813/lib2813/limelight/LocationalData.java
+++ b/limelight/src/main/java/com/team2813/lib2813/limelight/LocationalData.java
@@ -2,7 +2,6 @@ package com.team2813.lib2813.limelight;
 
 import java.util.Optional;
 import java.util.OptionalDouble;
-import java.util.OptionalLong;
 
 import edu.wpi.first.math.geometry.Pose3d;
 

--- a/limelight/src/main/java/com/team2813/lib2813/limelight/NetworkTablesLimelight.java
+++ b/limelight/src/main/java/com/team2813/lib2813/limelight/NetworkTablesLimelight.java
@@ -5,7 +5,6 @@ import static com.team2813.lib2813.limelight.Optionals.unboxDouble;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.OptionalDouble;
-import java.util.OptionalLong;
 
 import com.team2813.lib2813.limelight.LimelightHelpers.LimelightResults;
 import edu.wpi.first.math.geometry.Pose3d;

--- a/limelight/src/main/java/com/team2813/lib2813/limelight/RestLimelight.java
+++ b/limelight/src/main/java/com/team2813/lib2813/limelight/RestLimelight.java
@@ -53,7 +53,7 @@ class RestLimelight implements Limelight {
 		collectionThread.run();
 	}
 
-	String getName() {
+	public String getName() {
 		return name;
 	}
 
@@ -139,8 +139,8 @@ class RestLimelight implements Limelight {
 			if (simple) {
 				return true;
 			}
-			Integer intZero = Integer.valueOf(0);
-			Double doubleZero = Double.valueOf(0);
+			Integer intZero = 0;
+			Double doubleZero = 0d;
 			for (Object o : arr) {
 				if (!intZero.equals(o) && !doubleZero.equals(o)) {
 					return false;

--- a/limelight/src/test/java/com/team2813/lib2813/limelight/FakeLimelight.java
+++ b/limelight/src/test/java/com/team2813/lib2813/limelight/FakeLimelight.java
@@ -13,7 +13,7 @@ import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 
 public class FakeLimelight extends ExternalResource {
-	private static Logger logger = Logger.getLogger("FakeLimelight");
+	private static final Logger logger = Logger.getLogger("FakeLimelight");
 	HttpServer server;
 	@Override
 	protected void before() throws Throwable {
@@ -50,7 +50,7 @@ public class FakeLimelight extends ExternalResource {
 		}
 	}
 
-	private FakeGet resultsResponse = new FakeGet();
+	private final FakeGet resultsResponse = new FakeGet();
 
 	public void reset() {
 		resultsResponse.setBody("");

--- a/limelight/src/test/java/com/team2813/lib2813/limelight/LimelightTestCase.java
+++ b/limelight/src/test/java/com/team2813/lib2813/limelight/LimelightTestCase.java
@@ -9,21 +9,11 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.net.http.HttpResponse.BodyHandlers;
 import java.util.Optional;
 import java.util.OptionalDouble;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import edu.wpi.first.units.Units;
 import org.json.JSONObject;
-import org.junit.After;
-import org.junit.Rule;
 import org.junit.Test;
 
 import edu.wpi.first.math.geometry.Pose3d;

--- a/limelight/src/test/java/com/team2813/lib2813/limelight/NetworkTablesLimelightTest.java
+++ b/limelight/src/test/java/com/team2813/lib2813/limelight/NetworkTablesLimelightTest.java
@@ -1,25 +1,8 @@
 package com.team2813.lib2813.limelight;
 
-import edu.wpi.first.math.geometry.Pose3d;
-import edu.wpi.first.math.geometry.Rotation3d;
-import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableEntry;
 import org.json.JSONObject;
 import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.io.BufferedReader;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.ByteBuffer;
-import java.util.Optional;
-import java.util.OptionalDouble;
-import java.util.stream.Collectors;
-
-import static org.junit.Assert.*;
 
 public class NetworkTablesLimelightTest extends LimelightTestCase {
   private static final String TABLE_NAME = "limelight";

--- a/limelight/src/test/java/com/team2813/lib2813/limelight/RestLimelightTest.java
+++ b/limelight/src/test/java/com/team2813/lib2813/limelight/RestLimelightTest.java
@@ -1,32 +1,18 @@
 package com.team2813.lib2813.limelight;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
-import java.io.BufferedReader;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
-import java.util.Optional;
-import java.util.OptionalDouble;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.Test;
-
-import edu.wpi.first.math.geometry.Pose3d;
-import edu.wpi.first.math.geometry.Rotation3d;
 
 public class RestLimelightTest extends LimelightTestCase {
 	@ClassRule


### PR DESCRIPTION
- Remove unused imports
- Static methods on Interfaces are implicitly public
- Remove unnecessary boxing
- Mark fields that can be final as final