### PR TITLE
Update RestLimelight.getLocationalData() to return an immutable object

### DIFF
--- a/limelight/src/main/java/com/team2813/lib2813/limelight/JSONHelper.java
+++ b/limelight/src/main/java/com/team2813/lib2813/limelight/JSONHelper.java
@@ -46,42 +46,36 @@ class JSONHelper {
  		};
 	}
 
-	static Function<JSONObject, Optional<Long>> getLong(String key) {
-		return (j) -> {
-			if (!j.has(key)) {
-				return Optional.empty();
-			}
-			try {
-				return Optional.of(j.getLong(key));
-			} catch (JSONException e) {
-				return Optional.empty();
-			}
-		};
+	static Optional<Long> getLong(JSONObject obj, String key) {
+		if (!obj.has(key)) {
+			return Optional.empty();
+		}
+		try {
+			return Optional.of(obj.getLong(key));
+		} catch (JSONException e) {
+			return Optional.empty();
+		}
 	}
 
-	static Function<JSONObject, Optional<Double>> getDouble(String key) {
-		return (j) -> {
-			if (!j.has(key)) {
-				return Optional.empty();
-			}
-			try {
-				return Optional.of(j.getDouble(key));
-			} catch (JSONException e) {
-				return Optional.empty();
-			}
-		};
+	static Optional<Double> getDouble(JSONObject obj, String key) {
+		if (!obj.has(key)) {
+			return Optional.empty();
+		}
+		try {
+			return Optional.of(obj.getDouble(key));
+		} catch (JSONException e) {
+			return Optional.empty();
+		}
 	}
 	
-	static Function<JSONObject, Optional<JSONArray>> getArr(String key) {
-		return (obj) -> {
-			if (!obj.has(key)) {
-				return Optional.empty();
-			}
-			try {
-				return Optional.of(obj.getJSONArray(key));
-			} catch (JSONException e) {
-				return Optional.empty();
-			}
-		};
+	static Optional<JSONArray> getArr(JSONObject obj, String key) {
+		if (!obj.has(key)) {
+			return Optional.empty();
+		}
+		try {
+			return Optional.of(obj.getJSONArray(key));
+		} catch (JSONException e) {
+			return Optional.empty();
+		}
 	}
 }

--- a/limelight/src/main/java/com/team2813/lib2813/limelight/Limelight.java
+++ b/limelight/src/main/java/com/team2813/lib2813/limelight/Limelight.java
@@ -15,16 +15,27 @@ public interface Limelight {
 		return RestLimelight.getDefaultLimelight();
 	}
 
+	/**
+	 * @deprecated use {@link LocationalData#getTimestamp()}
+	 */
+	@Deprecated
 	OptionalDouble getTimestamp();
 
+	/**
+	 * Returns {@code true} if the limelight has identified a target.
+	 *
+	 * @deprecated use {@link LocationalData#hasTarget()}
+	 */
+	@Deprecated
 	boolean hasTarget();
 
-	/**
-	 * Gets an object for getting locational data
-	 * @return an object for getting locational data
-	 */
+	/** Gets an object for getting locational data. */
 	LocationalData getLocationalData();
 
+	/**
+	 * @deprecated use {@link LocationalData#getCaptureLatency()}
+	 */
+	@Deprecated
 	OptionalDouble getCaptureLatency();
 
 	@Deprecated

--- a/limelight/src/main/java/com/team2813/lib2813/limelight/LocationalData.java
+++ b/limelight/src/main/java/com/team2813/lib2813/limelight/LocationalData.java
@@ -2,7 +2,6 @@ package com.team2813.lib2813.limelight;
 
 import java.util.Optional;
 import java.util.OptionalDouble;
-import java.util.OptionalLong;
 
 import edu.wpi.first.math.geometry.Pose3d;
 
@@ -12,15 +11,32 @@ import edu.wpi.first.math.geometry.Pose3d;
  */
 public interface LocationalData {
 
+	/** Returns {@code true} if the limelight has identified a target. */
+	boolean hasTarget();
+
+	/**
+	 * Gets the position of the robot with the center of the field as the origin.
+	 * @return The position of the robot
+	 */
 	Optional<Pose3d> getBotpose();
-	
+
+	/**
+	 * Gets the position of the robot with the blue driverstation as the origin
+	 * @return The position of the robot
+	 */
 	Optional<Pose3d> getBotposeBlue();
-	
+
+	/**
+	 * Gets the position of the robot with the red driverstation as the origin
+	 * @return The position of the robot
+	 */
 	Optional<Pose3d> getBotposeRed();
 
 	OptionalDouble getCaptureLatency();
 
 	OptionalDouble getTargetingLatency();
+
+	OptionalDouble getTimestamp();
 
 	default OptionalDouble lastMSDelay(){
 		OptionalDouble a = getCaptureLatency();

--- a/limelight/src/main/java/com/team2813/lib2813/limelight/NetworkTablesLimelight.java
+++ b/limelight/src/main/java/com/team2813/lib2813/limelight/NetworkTablesLimelight.java
@@ -1,11 +1,8 @@
 package com.team2813.lib2813.limelight;
 
-import static com.team2813.lib2813.limelight.Optionals.unboxDouble;
-
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.OptionalDouble;
-import java.util.OptionalLong;
 
 import com.team2813.lib2813.limelight.LimelightHelpers.LimelightResults;
 import edu.wpi.first.math.geometry.Pose3d;
@@ -21,12 +18,12 @@ class NetworkTablesLimelight implements Limelight {
   
   @Override
   public OptionalDouble getTimestamp() {
-    return unboxDouble(getResults().map(results -> results.timestamp_LIMELIGHT_publish));
+    return getLocationalData().getTimestamp();
   }
 
   @Override
   public boolean hasTarget() {
-    return getResults().map(results -> results.targets_Fiducials.length > 0).orElse(false);
+    return getLocationalData().hasTarget();
   }
 
   @Override
@@ -45,7 +42,7 @@ class NetworkTablesLimelight implements Limelight {
 
   @Override
   public OptionalDouble getCaptureLatency() {
-    return unboxDouble(getResults().map(results -> results.latency_capture));
+    return getLocationalData().getCaptureLatency();
   }
 
   private Optional<LimelightResults> getResults() {
@@ -56,45 +53,16 @@ class NetworkTablesLimelight implements Limelight {
     return Optional.empty();
   }
 
-  private static class StubLocationalData implements LocationalData {
-    static final StubLocationalData INSTANCE = new StubLocationalData();
-
-    @Override
-    public Optional<Pose3d> getBotpose() {
-      return Optional.empty();
-    }
-    
-    @Override
-    public Optional<Pose3d> getBotposeBlue() {
-      return Optional.empty();
-    }
-    
-    @Override
-    public Optional<Pose3d> getBotposeRed() {
-      return Optional.empty();
-    }
-
-    @Override
-    public OptionalDouble getCaptureLatency() {
-      return OptionalDouble.empty();
-    }
-
-    @Override
-    public OptionalDouble getTargetingLatency() {
-      return OptionalDouble.empty();
-    }
-
-    @Override
-    public OptionalDouble lastMSDelay() {
-      return OptionalDouble.empty();
-    }
-  }
-
   private static class NTLocationalData implements LocationalData {
     private final LimelightResults results;
 
     NTLocationalData(LimelightHelpers.LimelightResults results) {
       this.results = results;
+    }
+
+    @Override
+    public boolean hasTarget() {
+      return results.targets_Fiducials.length > 0;
     }
 
     @Override
@@ -106,7 +74,7 @@ class NetworkTablesLimelight implements Limelight {
     public Optional<Pose3d> getBotposeBlue() {
       return toPose3D(results.botpose_wpiblue);
     }
-    
+
     @Override
     public Optional<Pose3d> getBotposeRed() {
       return toPose3D(results.botpose_wpired);
@@ -120,6 +88,11 @@ class NetworkTablesLimelight implements Limelight {
     @Override
     public OptionalDouble getTargetingLatency() {
       return OptionalDouble.of(results.latency_pipeline);
+    }
+
+    @Override
+    public OptionalDouble getTimestamp() {
+      return OptionalDouble.of(results.timestamp_LIMELIGHT_publish);
     }
 
     private static Optional<Pose3d> toPose3D(double[] inData) {

--- a/limelight/src/main/java/com/team2813/lib2813/limelight/RestLimelight.java
+++ b/limelight/src/main/java/com/team2813/lib2813/limelight/RestLimelight.java
@@ -141,7 +141,7 @@ class RestLimelight implements Limelight {
 
 		@Override
 		public boolean hasTarget() {
-			return getArr("Fiducial").apply(root).map(not(JSONArray::isEmpty)).orElse(false);
+			return getArr(root, "Fiducial").map(not(JSONArray::isEmpty)).orElse(false);
 		}
 
 		private boolean invalidArray(JSONArray arr) {
@@ -173,22 +173,22 @@ class RestLimelight implements Limelight {
 
 		@Override
 		public OptionalDouble getTimestamp() {
-			return unboxDouble(getDouble("ts").apply(root));
+			return unboxDouble(getDouble(root, "ts"));
 		}
 
 		@Override
 		public OptionalDouble getCaptureLatency() {
-			return unboxDouble(getDouble("cl").apply(root));
+			return unboxDouble(getDouble(root, "cl"));
 		}
 
 		@Override
 		public OptionalDouble getTargetingLatency() {
-			return unboxDouble(getDouble("tl").apply(root));
+			return unboxDouble(getDouble(root, "tl"));
 		}
 
 		@Override
 		public Optional<Pose3d> getBotpose() {
-			return getArr("botpose").apply(root).flatMap(this::parseArr);
+			return getArr(root, "botpose").flatMap(this::parseArr);
 		}
 
 		/**
@@ -197,7 +197,7 @@ class RestLimelight implements Limelight {
 		 */
 		@Override
 		public Optional<Pose3d> getBotposeBlue() {
-			return getArr("botpose_wpiblue").apply(root).flatMap(this::parseArr);
+			return getArr(root, "botpose_wpiblue").flatMap(this::parseArr);
 		}
 
 		/**
@@ -206,14 +206,14 @@ class RestLimelight implements Limelight {
 		 */
 		@Override
 		public Optional<Pose3d> getBotposeRed() {
-			return getArr("botpose_wpired").apply(root).flatMap(this::parseArr);
+			return getArr(root, "botpose_wpired").flatMap(this::parseArr);
 		}
 
 		/**
 		 * Gets the id of the targeted tag.
 		 */
 		OptionalLong getTagID() {
-			return unboxLong(getLong("pID").apply(root));
+			return unboxLong(getLong(root, "pID"));
 		}
 	}
 }

--- a/limelight/src/main/java/com/team2813/lib2813/limelight/RestLimelight.java
+++ b/limelight/src/main/java/com/team2813/lib2813/limelight/RestLimelight.java
@@ -33,11 +33,7 @@ class RestLimelight implements Limelight {
 
 	boolean started = false;
 
-	// specific types of data;
-	private final LocationalData data;
-
 	RestLimelight(String address) {
-		data = new RestLocationalData();
 		this.name = address;
 		collectionThread = new DataCollection(address);
 	}
@@ -67,28 +63,28 @@ class RestLimelight implements Limelight {
 	 * @return The targeting latency
 	 */
 	public OptionalDouble getTargetingLatency() {
-		return unboxDouble(getJsonDump().flatMap(getRoot()).flatMap(getDouble("tl")));
+		return getLocationalData().getTargetingLatency();
 	}
 
 	public OptionalDouble getCaptureLatency() {
-		return unboxDouble(getJsonDump().flatMap(getRoot()).flatMap(getDouble("cl")));
+		return getLocationalData().getCaptureLatency();
 	}
 
 	@Override
 	public OptionalDouble getTimestamp() {
-		return unboxDouble(getJsonDump().flatMap(getRoot()).flatMap(getDouble("ts")));
+		return getLocationalData().getTimestamp();
 	}
 
 	private static <T> Function<T, Boolean> not(Function<? super T, Boolean> fnc) {
 		return (t) -> !fnc.apply(t);
-	} 
+	}
 
 	public boolean hasTarget() {
-		return getJsonDump().flatMap(getRoot()).flatMap(getArr("Fiducial")).map(not(JSONArray::isEmpty)).orElse(false);
+		return getLocationalData().hasTarget();
 	}
 
 	public LocationalData getLocationalData() {
-		return data;
+		return getJsonDump().flatMap(getRoot()).map(RestLocationalData::fromJsonDump).orElse(StubLocationalData.INSTANCE);
 	}
 
 	private void clean() {
@@ -132,7 +128,21 @@ class RestLimelight implements Limelight {
 		limelights.clear();
 	}
 	
-	private class RestLocationalData implements LocationalData {
+	private static class RestLocationalData implements LocationalData {
+		private final JSONObject root;
+
+		static LocationalData fromJsonDump(JSONObject root) {
+			return new RestLocationalData(root);
+		}
+
+		RestLocationalData(JSONObject root) {
+			this.root = root;
+		}
+
+		@Override
+		public boolean hasTarget() {
+			return getArr("Fiducial").apply(root).map(not(JSONArray::isEmpty)).orElse(false);
+		}
 
 		private boolean invalidArray(JSONArray arr) {
 			boolean simple = arr.length() != 6 || !hasTarget();
@@ -162,21 +172,23 @@ class RestLimelight implements Limelight {
 		}
 
 		@Override
+		public OptionalDouble getTimestamp() {
+			return unboxDouble(getDouble("ts").apply(root));
+		}
+
+		@Override
 		public OptionalDouble getCaptureLatency() {
-			return RestLimelight.this.getCaptureLatency();
+			return unboxDouble(getDouble("cl").apply(root));
 		}
 
 		@Override
 		public OptionalDouble getTargetingLatency() {
-			return RestLimelight.this.getTargetingLatency();
+			return unboxDouble(getDouble("tl").apply(root));
 		}
 
-		/**
-		 * Gets the position of the robot with the center of the field as the origin
-		 * @return The position of the robot
-		 */
+		@Override
 		public Optional<Pose3d> getBotpose() {
-			return getJsonDump().flatMap(getRoot()).flatMap(getArr("botpose")).flatMap(this::parseArr);
+			return getArr("botpose").apply(root).flatMap(this::parseArr);
 		}
 
 		/**
@@ -185,7 +197,7 @@ class RestLimelight implements Limelight {
 		 */
 		@Override
 		public Optional<Pose3d> getBotposeBlue() {
-			return getJsonDump().flatMap(getRoot()).flatMap(getArr("botpose_wpiblue")).flatMap(this::parseArr);
+			return getArr("botpose_wpiblue").apply(root).flatMap(this::parseArr);
 		}
 
 		/**
@@ -194,14 +206,14 @@ class RestLimelight implements Limelight {
 		 */
 		@Override
 		public Optional<Pose3d> getBotposeRed() {
-			return getJsonDump().flatMap(getRoot()).flatMap(getArr("botpose_wpired")).flatMap(this::parseArr);
+			return getArr("botpose_wpired").apply(root).flatMap(this::parseArr);
 		}
 
 		/**
 		 * Gets the id of the targeted tag.
 		 */
-		public OptionalLong getTagID() {
-			return unboxLong(getJsonDump().flatMap(getRoot()).flatMap(getLong("pID")));
+		OptionalLong getTagID() {
+			return unboxLong(getLong("pID").apply(root));
 		}
 	}
 }

--- a/limelight/src/main/java/com/team2813/lib2813/limelight/StubLocationalData.java
+++ b/limelight/src/main/java/com/team2813/lib2813/limelight/StubLocationalData.java
@@ -1,0 +1,51 @@
+package com.team2813.lib2813.limelight;
+
+import edu.wpi.first.math.geometry.Pose3d;
+
+import java.util.Optional;
+import java.util.OptionalDouble;
+
+/** Implementation of LocationalData where all optional values return empty values. */
+class StubLocationalData implements LocationalData {
+  static final StubLocationalData INSTANCE = new StubLocationalData();
+
+  @Override
+  public boolean hasTarget() {
+    return false;
+  }
+
+  @Override
+  public Optional<Pose3d> getBotpose() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Pose3d> getBotposeBlue() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Pose3d> getBotposeRed() {
+    return Optional.empty();
+  }
+
+  @Override
+  public OptionalDouble getCaptureLatency() {
+    return OptionalDouble.empty();
+  }
+
+  @Override
+  public OptionalDouble getTargetingLatency() {
+    return OptionalDouble.empty();
+  }
+
+  @Override
+  public OptionalDouble getTimestamp() {
+    return OptionalDouble.empty();
+  }
+
+  @Override
+  public OptionalDouble lastMSDelay() {
+    return OptionalDouble.empty();
+  }
+}

--- a/limelight/src/main/java/com/team2813/lib2813/limelight/StubLocationalData.java
+++ b/limelight/src/main/java/com/team2813/lib2813/limelight/StubLocationalData.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 
 /** Implementation of LocationalData where all optional values return empty values. */
-class StubLocationalData implements LocationalData {
+final class StubLocationalData implements LocationalData {
   static final StubLocationalData INSTANCE = new StubLocationalData();
 
   @Override


### PR DESCRIPTION
This fixes issues where callers can get inconsistent data if new data is fetched while the robot is reading limelight data.

Previously, the object returned by getLocationData() would proxy to RestLimelight,
so would return the most recent data.