### PR TITLE
Create PreferencesRegistry and deprecate PreferencesInjector

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -25,7 +25,7 @@ tasks.withType(JavaCompile) {
     options.compilerArgs.add '-XDstringConcat=inline'
 }
 
-version = '1.2.0'
+version = '1.3.0-alpha.1'
 
 repositories {
     // Use Maven Central for resolving dependencies.

--- a/lib/src/main/java/com/team2813/lib2813/preferences/PersistedConfiguration.java
+++ b/lib/src/main/java/com/team2813/lib2813/preferences/PersistedConfiguration.java
@@ -1,0 +1,367 @@
+package com.team2813.lib2813.preferences;
+
+import static edu.wpi.first.networktables.NetworkTable.PATH_SEPARATOR;
+
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.wpilibj.DataLogManager;
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.Preferences;
+import java.lang.reflect.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.*;
+
+/**
+ * Initializes the fields of a Record Class from values stored in {@link Preferences}.
+ *
+ * <p>Example use:
+ *
+ * {@snippet :
+ * public final class Drive {
+ *
+ *   public record DriveConfiguration(
+ *       boolean addVisionMeasurements, long robotWeight,
+ *       DoubleSupplier powerMultiplier) {
+ *
+ *     public static DriveConfiguration fromPreferences() {
+ *       DriveConfiguration defaultConfig = new DriveConfiguration(
+ *           true, 1337, () -> 3.14);
+ *       return PersistedConfiguration.fromPreferences("Drive", defaultConfig);
+ *     }
+ *   }
+ * }
+ * }
+ *
+ * <p>In the above example, {@code fromPreferences()} would return a record instance with the values
+ * populated the "Preferences" NetworkTables table. The keys would be:
+ *
+ * <ul>
+ *   <li>{@code "Drive.DriveConfiguration.addLimelightMeasurement"}
+ *   <li>{@code "Drive.DriveConfiguration.robotWeight"}
+ *   <li>{@code "Drive.DriveConfiguration.powerMultiplier"}
+ * </ul>
+ *
+ * <p>The default values of for these Preference values will be the values provided to {@link
+ * PersistedConfiguration#fromPreferences(String, Record)}. The values can be updated in the
+ * SmartDashboard and/or Shuffleboard UI; updated values will be stored in the flash storage for the
+ * robot. In the above example, if none of the above preference keys existed, preferences will be
+ * created with the following values:
+ *
+ * <ul>
+ *   <li>{@code "Drive.DriveConfiguration.addLimelightMeasurement"}: {@code true}
+ *   <li>{@code "Drive.DriveConfiguration.robotWeight"}: 1337
+ *   <li>{@code "Drive.DriveConfiguration.powerMultiplier"}: 3.14
+ * </ul>
+ *
+ * <p>For record classes with many component values of the same type, it is strongly recommended
+ * that a builder is provided to construct the record, to avoid callers passing the parameters in
+ * the wrong order. To make generation of a builder easier, consider using <a
+ * href="https://github.com/google/auto/blob/main/value/userguide/autobuilder.md">{@code @AutoBuilder}</a>
+ * from Google Auto or <a href="https://projectlombok.org/features/Builder">{@code @Builder}</a>
+ * from Project Lombok. Note that {@code PersistedConfiguration} will use the default record
+ * constructor to create record instances, so any parameter validation should be done in a custom
+ * constructor; see <a href="https://www.baeldung.com/java-records-custom-constructor">Custom
+ * Constructor in Java Records</a> for details.
+ */
+public final class PersistedConfiguration {
+  // The below package-scope fields are for the self-tests.
+  static boolean throwExceptions = false;
+  static Consumer<String> errorReporter = DataLogManager::log;
+
+  /**
+   * Creates a record class instance with fields populated from Preferences, using the provided
+   * defaults.
+   *
+   * <p>To be stored in preferences, the type of the record components can be any of the following:
+   *
+   * <ul>
+   *   <li>{@code boolean} or {@code BooleanSupplier} or {@code Supplier<Boolean>}
+   *   <li>{@code int} or {@code IntSupplier} or {@code Supplier<Integer>}
+   *   <li>{@code long} or {@code LongSupplier} or {@code Supplier<Long>}
+   *   <li>{@code double} or {@code DoubleSupplier} or {@code Supplier<Double>}
+   *   <li>{@code String} or {@code Supplier<String>}
+   *   <li>{@code Record} following the above rules
+   * </ul>
+   *
+   * <p>The values for the components for the passed-in instance will be used as the default value
+   * for the preference. If a component is a supplier, the supplier will be called at most once to
+   * get the default instance. Suppliers cannot return {@code null}.
+   *
+   * @param preferenceName Preference subtable to use to get the values.
+   * @param configWithDefaults Record instance with all values set to their preferred default
+   *     values.
+   * @throws IllegalArgumentException If {@code preferenceName} is empty or contains a {@code '/'}.
+   * @throws IllegalStateException If {@code preferenceName} was used for a different record class.
+   */
+  public static <T extends Record> T fromPreferences(String preferenceName, T configWithDefaults) {
+    return fromPreferences(preferenceName, configWithDefaults, PATH_SEPARATOR);
+  }
+
+  static <T extends Record> T fromPreferences(
+      String preferenceName, T configWithDefaults, char pathSeparator) {
+    @SuppressWarnings("unchecked")
+    Class<T> recordClass = (Class<T>) configWithDefaults.getClass();
+
+    NetworkTableInstance ntInstance = NetworkTableInstance.getDefault();
+    validatePreferenceName(preferenceName);
+    verifyNotRegisteredToAnotherClass(ntInstance, preferenceName, recordClass);
+
+    try {
+      return createFromPreferences(preferenceName, recordClass, configWithDefaults, pathSeparator);
+    } catch (ReflectiveOperationException e) {
+      if (throwExceptions) {
+        throw new RuntimeException(e); // For self-tests.
+      }
+      DriverStation.reportWarning(
+          String.format("Could not copy preferences into %s: %s", recordClass.getSimpleName(), e),
+          e.getStackTrace());
+      return configWithDefaults;
+    }
+  }
+
+  private static void validatePreferenceName(String name) {
+    if (name.isEmpty()) {
+      throw new IllegalArgumentException("name cannot be empty");
+    }
+    if (name.indexOf(PATH_SEPARATOR) >= 0) {
+      throw new IllegalArgumentException(String.format("name cannot contain '%c'", PATH_SEPARATOR));
+    }
+  }
+
+  private static void verifyNotRegisteredToAnotherClass(
+      NetworkTableInstance ntInstance, String name, Class<? extends Record> recordClass) {
+    String recordName = recordClass.getCanonicalName();
+    if (recordName == null) {
+      recordName = recordClass.getName();
+    }
+
+    NetworkTable preferencesTable = ntInstance.getTable("Preferences");
+    NetworkTableEntry entry =
+        preferencesTable.getEntry(String.format("%s%c.registeredTo", name, PATH_SEPARATOR));
+    if (!entry.exists()) {
+      entry.setString(recordName);
+    } else {
+      String registeredTo = entry.getString("");
+      if (!recordName.equals(registeredTo)) {
+        throw new IllegalStateException(
+            String.format(
+                "Preference with name '%s' already registered to %s", name, registeredTo));
+      }
+    }
+  }
+
+  private static <T> T createFromPreferences(
+      String prefix, Class<? extends T> clazz, T configWithDefaults, char pathSeparator)
+      throws ReflectiveOperationException {
+    var components = clazz.getRecordComponents();
+    Object[] params = new Object[components.length];
+    Class<?>[] types = new Class[components.length];
+    int i = 0;
+    for (RecordComponent component : components) {
+      String name = component.getName();
+      String key = prefix + pathSeparator + name;
+      Class<?> type = component.getType();
+      types[i] = type;
+
+      boolean needComponentValue;
+      PreferenceFactory factory = null;
+      boolean isRecordField = Record.class.isAssignableFrom(type);
+      if (isRecordField) {
+        needComponentValue = true;
+      } else {
+        factory = TYPE_TO_FACTORY.get(type);
+        if (factory == null) {
+          // Cannot get value from Preferences; copy over the value from the input record.
+          needComponentValue = true;
+        } else {
+          needComponentValue = !Preferences.containsKey(key);
+        }
+      }
+
+      Object componentValue = null;
+      if (needComponentValue) {
+        if (configWithDefaults != null) {
+          Field defaultValueField = clazz.getDeclaredField(name);
+          defaultValueField.setAccessible(true);
+          componentValue = defaultValueField.get(configWithDefaults);
+        }
+      }
+
+      if (isRecordField) {
+        params[i] = createFromPreferences(key, type, componentValue, pathSeparator);
+      } else if (factory == null) {
+        warn("Cannot store '%s' in Preferences; type %s is unsupported", name, type);
+        params[i] = componentValue;
+      } else {
+        // Fetch the value from Preferences
+        params[i] = factory.create(component, key, componentValue);
+      }
+      i++;
+    }
+    Constructor<? extends T> constructor = clazz.getDeclaredConstructor(types);
+    constructor.setAccessible(true);
+    return constructor.newInstance(params);
+  }
+
+  @FunctionalInterface
+  private interface PreferenceFactory {
+    Object create(RecordComponent component, String key, Object defaultValue);
+  }
+
+  @FunctionalInterface
+  private interface GenericPreferenceFactory<T> {
+    T create(RecordComponent component, String key, T defaultValue);
+  }
+
+  private static final Map<Type, PreferenceFactory> TYPE_TO_FACTORY = new HashMap<>();
+
+  @SuppressWarnings("unchecked")
+  private static <T> void register(Class<T> type, GenericPreferenceFactory<T> simpleFactory) {
+    PreferenceFactory factory =
+        (component, key, defaultValue) -> simpleFactory.create(component, key, (T) defaultValue);
+    TYPE_TO_FACTORY.put(type, factory);
+  }
+
+  static {
+    register(Boolean.TYPE, PersistedConfiguration::booleanFactory);
+    register(BooleanSupplier.class, PersistedConfiguration::booleanSupplierFactory);
+    register(Integer.TYPE, PersistedConfiguration::intFactory);
+    register(IntSupplier.class, PersistedConfiguration::intSupplierFactory);
+    register(Long.TYPE, PersistedConfiguration::longFactory);
+    register(LongSupplier.class, PersistedConfiguration::longSupplierFactory);
+    register(Double.TYPE, PersistedConfiguration::doubleFactory);
+    register(DoubleSupplier.class, PersistedConfiguration::doubleSupplierFactory);
+    register(String.class, PersistedConfiguration::stringFactory);
+    register(Supplier.class, PersistedConfiguration::supplierFactory);
+  }
+
+  /** Maps the generic types supported by Preferences to their primitive types. */
+  private static final Map<Type, Type> SUPPLIER_TYPE_TO_REGISTERED_TYPE =
+      Map.of(
+          Boolean.class, Boolean.TYPE,
+          Integer.class, Integer.TYPE,
+          Long.class, Long.TYPE,
+          Double.class, Double.TYPE,
+          String.class, String.class);
+
+  /** Gets a boolean value from Preferences for the given component. */
+  private static boolean booleanFactory(
+      RecordComponent component, String key, Boolean defaultValue) {
+    if (defaultValue != null) {
+      Preferences.initBoolean(key, defaultValue);
+    }
+    return Preferences.getBoolean(key, false);
+  }
+
+  /** Gets a BooleanSupplier value from Preferences for the given component. */
+  private static BooleanSupplier booleanSupplierFactory(
+      RecordComponent component, String key, BooleanSupplier defaultValueSupplier) {
+    if (defaultValueSupplier != null) {
+      boolean defaultValue = defaultValueSupplier.getAsBoolean();
+      Preferences.initBoolean(key, defaultValue);
+    }
+    return () -> Preferences.getBoolean(key, false);
+  }
+
+  /** Gets an int value from Preferences for the given component. */
+  private static int intFactory(RecordComponent component, String key, Integer defaultValue) {
+    if (defaultValue != null) {
+      Preferences.initInt(key, defaultValue);
+    }
+    return Preferences.getInt(key, 0);
+  }
+
+  /** Gets a IntSupplier value from Preferences for the given component. */
+  private static IntSupplier intSupplierFactory(
+      RecordComponent component, String key, IntSupplier defaultValueSupplier) {
+    if (defaultValueSupplier != null) {
+      int defaultValue = defaultValueSupplier.getAsInt();
+      Preferences.initInt(key, defaultValue);
+    }
+    return () -> Preferences.getInt(key, 0);
+  }
+
+  /** Gets a long value from Preferences for the given component. */
+  private static long longFactory(RecordComponent component, String key, Long defaultValue) {
+    if (defaultValue != null) {
+      Preferences.initLong(key, defaultValue);
+    }
+    return Preferences.getLong(key, 0);
+  }
+
+  /** Gets a LongSupplier value from Preferences for the given component. */
+  private static LongSupplier longSupplierFactory(
+      RecordComponent component, String key, LongSupplier defaultValueSupplier) {
+    if (defaultValueSupplier != null) {
+      long defaultValue = defaultValueSupplier.getAsLong();
+      Preferences.initLong(key, defaultValue);
+    }
+    return () -> Preferences.getLong(key, 0);
+  }
+
+  /** Gets a double value from Preferences for the given component. */
+  private static double doubleFactory(RecordComponent component, String key, Double defaultValue) {
+    if (defaultValue != null) {
+      Preferences.initDouble(key, defaultValue);
+    }
+    return Preferences.getDouble(key, 0);
+  }
+
+  /** Gets a DoubleSupplier value from Preferences for the given component. */
+  private static DoubleSupplier doubleSupplierFactory(
+      RecordComponent component, String key, DoubleSupplier defaultValueSupplier) {
+    if (defaultValueSupplier != null) {
+      double defaultValue = defaultValueSupplier.getAsDouble();
+      Preferences.initDouble(key, defaultValue);
+    }
+    return () -> Preferences.getDouble(key, 0);
+  }
+
+  /** Gets a String value from Preferences for the given component. */
+  private static String stringFactory(RecordComponent component, String key, String defaultValue) {
+    if (defaultValue != null) {
+      Preferences.initString(key, defaultValue);
+    }
+    return Preferences.getString(key, "");
+  }
+
+  /**
+   * Gets a Supplier value from Preferences for the given component. Supports String, long, int,
+   * boolean and float values.
+   */
+  private static Supplier<?> supplierFactory(
+      RecordComponent component, String key, Supplier<?> defaultValueSupplier) {
+    Type supplierType =
+        ((ParameterizedType) component.getGenericType()).getActualTypeArguments()[0];
+    Type registeredType = SUPPLIER_TYPE_TO_REGISTERED_TYPE.get(supplierType);
+    if (registeredType == null) {
+      warn(
+          "Cannot store '%s' in Preferences; type %s is unsupported",
+          component.getName(), component.getGenericType());
+      return defaultValueSupplier;
+    }
+    PreferenceFactory factory = TYPE_TO_FACTORY.get(registeredType);
+
+    if (defaultValueSupplier != null) {
+      Object defaultValue = defaultValueSupplier.get();
+      if (defaultValue == null) {
+        warn("Cannot store '%s' in Preferences; default value is null", component.getName());
+        return defaultValueSupplier;
+      }
+      factory.create(component, key, defaultValue); // Call Preferences.init{String,Double,etc}()
+    }
+
+    return () -> factory.create(component, key, null);
+  }
+
+  private static void warn(String format, Object... args) {
+    String message = String.format("WARNING: " + format, args);
+    errorReporter.accept(message);
+  }
+
+  private PersistedConfiguration() {
+    throw new AssertionError("Not instantiable");
+  }
+}

--- a/lib/src/test/java/com/team2813/lib2813/preferences/PersistedConfigurationTest.java
+++ b/lib/src/test/java/com/team2813/lib2813/preferences/PersistedConfigurationTest.java
@@ -1,0 +1,658 @@
+package com.team2813.lib2813.preferences;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+import static java.util.stream.Collectors.toMap;
+
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.Topic;
+import edu.wpi.first.wpilibj.DataLogManager;
+import edu.wpi.first.wpilibj.Preferences;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.rules.ErrorCollector;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/** Tests for {@link PersistedConfiguration}. */
+@RunWith(Enclosed.class)
+public final class PersistedConfigurationTest {
+  private static final double EPSILON = 0.001;
+
+  /** Base class for all nested classes of {@link PersistedConfigurationTest}. */
+  abstract static class PreferencesRegistryTestCase<T extends Record> {
+    private final String preferenceName;
+
+    @Rule public final IsolatedPreferences isolatedPreferences = new IsolatedPreferences();
+    @Rule public final ErrorCollector errorCollector = new ErrorCollector();
+
+    protected PreferencesRegistryTestCase(String preferenceName) {
+      this.preferenceName = preferenceName;
+    }
+
+    @Before
+    public final void setTestGlobals() {
+      PersistedConfiguration.throwExceptions = true;
+      PersistedConfiguration.errorReporter =
+          message ->
+              errorCollector.addError(
+                  new AssertionError("Unexpected warning: \"" + message + "\""));
+    }
+
+    @After
+    public final void resetTestGlobals() {
+      PersistedConfiguration.throwExceptions = false;
+      PersistedConfiguration.errorReporter = DataLogManager::log;
+    }
+
+    protected enum ValuesKind {
+      INITIAL_VALUES,
+      UPDATED_VALUES
+    }
+
+    protected final void assertHasNoChangesSince(Map<String, Object> previousValues) {
+      var preferenceValues = preferenceValues();
+      assertWithMessage("Unexpected no changes to preference values")
+          .that(preferenceValues)
+          .isEqualTo(previousValues);
+    }
+
+    protected final Map<String, Object> preferenceValues() {
+      NetworkTable table = isolatedPreferences.getPreferencesTable();
+      return preferenceKeys().stream()
+          .collect(toMap(Function.identity(), key -> table.getEntry(key).getValue().getValue()));
+    }
+
+    protected final Set<String> preferenceKeys() {
+      NetworkTable table = isolatedPreferences.getPreferencesTable();
+      Set<String> keys = new HashSet<>();
+      collectKeys(table, keys);
+      return Set.copyOf(keys);
+    }
+
+    private void collectKeys(NetworkTable table, Set<String> result) {
+      for (String key : table.getSubTables()) {
+        collectKeys(table.getSubTable(key), result);
+      }
+      for (Topic topic : table.getTopics()) {
+        String topicName = topic.getName().substring(13); // Remove "/Preferences/" prefix
+
+        // Preferences adds a ".type" key; we filter it out here.
+        if (!topicName.startsWith(".") && !topicName.contains("/.")) {
+          result.add(topicName);
+        }
+      }
+    }
+
+    /**
+     * Creates an instance of the record class with all values set to default values.
+     *
+     * <p>The values for the record components should all be unique, and none of them should be the
+     * Java default value for the type.
+     */
+    protected abstract T createRecordWithConfiguredDefaults();
+
+    /**
+     * Verifies that the given record has the same values as one created by {@link
+     * #createRecordWithConfiguredDefaults()}.
+     */
+    protected abstract void assertHasConfiguredDefaults(T record);
+
+    /**
+     * Verifies that preferences have the same values as one created by {@link
+     * #createRecordWithConfiguredDefaults()}.
+     */
+    protected abstract void assertPreferencesHaveConfiguredDefaults();
+
+    /** Updates the values of all preferences. */
+    protected abstract void updatePreferenceValues(ValuesKind kind);
+
+    /**
+     * Verifies that all values of the given record equal the values returned by {@link
+     * #updatePreferenceValues(ValuesKind)}.
+     */
+    protected abstract void assertHasUpdatedValues(ValuesKind kind, T record);
+
+    /**
+     * Verifies that all suppliers contained in the given record have values equal the values
+     * returned by {@link #updatePreferenceValues(ValuesKind)}.
+     */
+    protected abstract void assertSuppliersHaveUpdatedValues(T record);
+
+    @Test
+    public void withoutExistingPreferences() {
+      // Arrange
+      T recordWithDefaults = createRecordWithConfiguredDefaults();
+
+      // Act
+      T recordWithPreferences =
+          PersistedConfiguration.fromPreferences(preferenceName, recordWithDefaults);
+
+      // Assert: Preferences injected
+      assertHasConfiguredDefaults(recordWithPreferences);
+
+      // Assert: Default values set
+      assertPreferencesHaveConfiguredDefaults();
+
+      // Arrange: Update preferences
+      updatePreferenceValues(ValuesKind.UPDATED_VALUES);
+      var preferenceValues = preferenceValues();
+
+      // Act
+      T newRecordWithPreferences =
+          PersistedConfiguration.fromPreferences(preferenceName, recordWithDefaults);
+
+      // Assert: Preferences injected
+      assertHasUpdatedValues(ValuesKind.UPDATED_VALUES, newRecordWithPreferences);
+      assertSuppliersHaveUpdatedValues(recordWithPreferences);
+      assertHasNoChangesSince(preferenceValues);
+    }
+
+    @Test
+    public void withExistingPreferences() {
+      // Arrange
+      updatePreferenceValues(ValuesKind.INITIAL_VALUES);
+      var preferenceValues = preferenceValues();
+      T recordWithDefaults = createRecordWithConfiguredDefaults();
+
+      // Act
+      T recordWithPreferences =
+          PersistedConfiguration.fromPreferences(preferenceName, recordWithDefaults);
+
+      // Assert: Preferences injected
+      assertHasUpdatedValues(ValuesKind.INITIAL_VALUES, recordWithPreferences);
+      assertHasNoChangesSince(preferenceValues);
+
+      // Arrange: Update preferences
+      updatePreferenceValues(ValuesKind.UPDATED_VALUES);
+      preferenceValues = preferenceValues();
+
+      // Act
+      var newRecordWithPreferences =
+          PersistedConfiguration.fromPreferences(preferenceName, recordWithDefaults);
+
+      // Assert: Preferences injected
+      assertHasUpdatedValues(ValuesKind.UPDATED_VALUES, newRecordWithPreferences);
+      assertSuppliersHaveUpdatedValues(recordWithPreferences);
+      assertHasNoChangesSince(preferenceValues);
+    }
+  }
+
+  @RunWith(Parameterized.class)
+  public static class BooleanPreferencesTest
+      extends PreferencesRegistryTestCase<BooleanPreferencesTest.RecordWithBooleans> {
+    static final String PREFERENCE_NAME = "Booleans";
+    static final String BOOLEAN_VALUE_KEY = "Booleans/booleanValue";
+    static final String BOOLEAN_SUPPLIER_KEY = "Booleans/booleanSupplier";
+    static final String SUPPLIER_BOOLEAN_KEY = "Booleans/supplierBoolean";
+    static final Set<String> ALL_KEYS =
+        Set.of(BOOLEAN_VALUE_KEY, BOOLEAN_SUPPLIER_KEY, SUPPLIER_BOOLEAN_KEY);
+    final boolean defaultValue;
+
+    @Parameters(name = "defaultValue={0}")
+    public static Object[] data() {
+      return new Object[] {true, false};
+    }
+
+    public BooleanPreferencesTest(boolean defaultValue) {
+      super(PREFERENCE_NAME);
+      this.defaultValue = defaultValue;
+    }
+
+    /** Test record for testing classes that contain boolean fields. */
+    private record RecordWithBooleans(
+        boolean booleanValue, BooleanSupplier booleanSupplier, Supplier<Boolean> supplierBoolean) {
+
+      static RecordWithBooleans withDefaultValue(boolean defaultValue) {
+        return new RecordWithBooleans(
+            defaultValue, () -> defaultValue, () -> Boolean.valueOf(defaultValue));
+      }
+    }
+
+    @Override
+    protected RecordWithBooleans createRecordWithConfiguredDefaults() {
+      return RecordWithBooleans.withDefaultValue(defaultValue);
+    }
+
+    @Override
+    protected void assertHasConfiguredDefaults(RecordWithBooleans record) {
+      assertThat(record.booleanValue()).isEqualTo(defaultValue);
+      assertThat(record.booleanSupplier().getAsBoolean()).isEqualTo(defaultValue);
+      assertThat(record.supplierBoolean().get()).isEqualTo(Boolean.valueOf(defaultValue));
+    }
+
+    @Override
+    protected void assertPreferencesHaveConfiguredDefaults() {
+      assertThat(preferenceKeys())
+          .containsExactly(BOOLEAN_VALUE_KEY, BOOLEAN_SUPPLIER_KEY, SUPPLIER_BOOLEAN_KEY);
+      for (String key : ALL_KEYS) {
+        assertThat(Preferences.getBoolean(key, !defaultValue)).isEqualTo(defaultValue);
+      }
+    }
+
+    private boolean getUpdatedValue(ValuesKind kind) {
+      return switch (kind) {
+        case INITIAL_VALUES -> !defaultValue;
+        case UPDATED_VALUES -> defaultValue;
+      };
+    }
+
+    @Override
+    protected void updatePreferenceValues(ValuesKind kind) {
+      boolean newValue = getUpdatedValue(kind);
+      for (String key : ALL_KEYS) {
+        Preferences.setBoolean(key, newValue);
+      }
+    }
+
+    @Override
+    protected void assertHasUpdatedValues(ValuesKind kind, RecordWithBooleans record) {
+      boolean expectedValue = getUpdatedValue(kind);
+      assertThat(record.booleanValue()).isEqualTo(expectedValue);
+      assertThat(record.booleanSupplier().getAsBoolean()).isEqualTo(expectedValue);
+      assertThat(record.supplierBoolean().get()).isEqualTo(Boolean.valueOf(expectedValue));
+    }
+
+    @Override
+    protected void assertSuppliersHaveUpdatedValues(RecordWithBooleans record) {
+      boolean expectedValue = getUpdatedValue(ValuesKind.UPDATED_VALUES);
+      assertThat(record.booleanSupplier().getAsBoolean()).isEqualTo(expectedValue);
+      assertThat(record.supplierBoolean().get()).isEqualTo(Boolean.valueOf(expectedValue));
+    }
+  }
+
+  public static class IntPreferencesTest
+      extends PreferencesRegistryTestCase<IntPreferencesTest.RecordWithInts> {
+    static final String PREFERENCE_NAME = "Integers";
+    static final String INT_VALUE_KEY = "Integers/intValue";
+    static final String INT_SUPPLIER_KEY = "Integers/intSupplier";
+    static final String SUPPLIER_INT_KEY = "Integers/supplierInt";
+
+    public IntPreferencesTest() {
+      super(PREFERENCE_NAME);
+    }
+
+    /** Test record for testing classes that contain int fields. */
+    private record RecordWithInts(
+        int intValue, IntSupplier intSupplier, Supplier<Integer> supplierInt) {
+
+      static RecordWithInts withDefaultValues(
+          int intValue, int intSupplierValue, int supplierIntValue) {
+        return new RecordWithInts(intValue, () -> intSupplierValue, () -> supplierIntValue);
+      }
+    }
+
+    @Override
+    protected RecordWithInts createRecordWithConfiguredDefaults() {
+      return RecordWithInts.withDefaultValues(1, 2, 3);
+    }
+
+    @Override
+    protected void assertHasConfiguredDefaults(RecordWithInts record) {
+      assertThat(record.intValue()).isEqualTo(1);
+      assertThat(record.intSupplier.getAsInt()).isEqualTo(2);
+      assertThat(record.supplierInt().get()).isEqualTo(Integer.valueOf(3));
+    }
+
+    @Override
+    protected void assertPreferencesHaveConfiguredDefaults() {
+      assertThat(preferenceKeys())
+          .containsExactly(INT_VALUE_KEY, INT_SUPPLIER_KEY, SUPPLIER_INT_KEY);
+      assertThat(Preferences.getInt(INT_VALUE_KEY, -1)).isEqualTo(1);
+      assertThat(Preferences.getInt(INT_SUPPLIER_KEY, -1)).isEqualTo(2);
+      assertThat(Preferences.getInt(SUPPLIER_INT_KEY, -1)).isEqualTo(3);
+    }
+
+    @Override
+    protected void updatePreferenceValues(ValuesKind kind) {
+      switch (kind) {
+        case INITIAL_VALUES -> {
+          Preferences.setInt(INT_VALUE_KEY, 101);
+          Preferences.setInt(INT_SUPPLIER_KEY, 102);
+          Preferences.setInt(SUPPLIER_INT_KEY, 103);
+        }
+        case UPDATED_VALUES -> {
+          Preferences.setInt(INT_VALUE_KEY, 201);
+          Preferences.setInt(INT_SUPPLIER_KEY, 202);
+          Preferences.setInt(SUPPLIER_INT_KEY, 203);
+        }
+      }
+    }
+
+    @Override
+    protected void assertHasUpdatedValues(ValuesKind kind, RecordWithInts record) {
+      switch (kind) {
+        case INITIAL_VALUES -> {
+          assertThat(record.intValue()).isEqualTo(101);
+          assertThat(record.intSupplier.getAsInt()).isEqualTo(102);
+          assertThat(record.intSupplier.getAsInt()).isEqualTo(102);
+          assertThat(record.supplierInt().get()).isEqualTo(Integer.valueOf(103));
+          assertThat(record.supplierInt().get()).isEqualTo(Integer.valueOf(103));
+        }
+        case UPDATED_VALUES -> {
+          assertThat(record.intValue()).isEqualTo(201);
+          assertThat(record.intSupplier.getAsInt()).isEqualTo(202);
+          assertThat(record.intSupplier.getAsInt()).isEqualTo(202);
+          assertThat(record.supplierInt().get()).isEqualTo(Integer.valueOf(203));
+          assertThat(record.supplierInt().get()).isEqualTo(Integer.valueOf(203));
+        }
+      }
+    }
+
+    @Override
+    protected void assertSuppliersHaveUpdatedValues(RecordWithInts record) {
+      assertThat(record.intSupplier.getAsInt()).isEqualTo(202);
+      assertThat(record.intSupplier.getAsInt()).isEqualTo(202);
+      assertThat(record.supplierInt().get()).isEqualTo(Integer.valueOf(203));
+      assertThat(record.supplierInt().get()).isEqualTo(Integer.valueOf(203));
+    }
+  }
+
+  public static class LongPreferencesTest
+      extends PreferencesRegistryTestCase<LongPreferencesTest.RecordWithLongs> {
+    static final String PREFERENCE_NAME = "Longs";
+    static final String LONG_VALUE_KEY = "Longs/longValue";
+    static final String LONG_SUPPLIER_KEY = "Longs/longSupplier";
+    static final String SUPPLIER_LONG_KEY = "Longs/supplierLong";
+
+    public LongPreferencesTest() {
+      super(PREFERENCE_NAME);
+    }
+
+    /** Test record for testing classes that contain long fields. */
+    private record RecordWithLongs(
+        long longValue, LongSupplier longSupplier, Supplier<Long> supplierLong) {
+
+      static RecordWithLongs withDefaultValues(
+          long longValue, long longSupplierValue, long supplierLongValue) {
+        return new RecordWithLongs(longValue, () -> longSupplierValue, () -> supplierLongValue);
+      }
+    }
+
+    @Override
+    protected RecordWithLongs createRecordWithConfiguredDefaults() {
+      return RecordWithLongs.withDefaultValues(1, 2, 3);
+    }
+
+    @Override
+    protected void assertHasConfiguredDefaults(RecordWithLongs record) {
+      assertThat(record.longValue()).isEqualTo(1);
+      assertThat(record.longSupplier.getAsLong()).isEqualTo(2);
+      assertThat(record.supplierLong().get()).isEqualTo(Long.valueOf(3));
+    }
+
+    @Override
+    protected void assertPreferencesHaveConfiguredDefaults() {
+      assertThat(preferenceKeys())
+          .containsExactly(LONG_VALUE_KEY, LONG_SUPPLIER_KEY, SUPPLIER_LONG_KEY);
+      assertThat(Preferences.getLong(LONG_VALUE_KEY, -1)).isEqualTo(1);
+      assertThat(Preferences.getLong(LONG_SUPPLIER_KEY, -1)).isEqualTo(2);
+      assertThat(Preferences.getLong(SUPPLIER_LONG_KEY, -1)).isEqualTo(3);
+    }
+
+    @Override
+    protected void updatePreferenceValues(ValuesKind kind) {
+      switch (kind) {
+        case INITIAL_VALUES -> {
+          Preferences.setLong(LONG_VALUE_KEY, 10);
+          Preferences.setLong(LONG_SUPPLIER_KEY, 20);
+          Preferences.setLong(SUPPLIER_LONG_KEY, 30);
+        }
+        case UPDATED_VALUES -> {
+          Preferences.setLong(LONG_VALUE_KEY, 100);
+          Preferences.setLong(LONG_SUPPLIER_KEY, 200);
+          Preferences.setLong(SUPPLIER_LONG_KEY, 300);
+        }
+      }
+    }
+
+    @Override
+    protected void assertHasUpdatedValues(ValuesKind kind, RecordWithLongs record) {
+      switch (kind) {
+        case INITIAL_VALUES -> {
+          assertThat(record.longValue()).isEqualTo(10);
+          assertThat(record.longSupplier.getAsLong()).isEqualTo(20);
+          assertThat(record.supplierLong().get()).isEqualTo(Long.valueOf(30));
+        }
+        case UPDATED_VALUES -> {
+          assertThat(record.longValue()).isEqualTo(100);
+          assertThat(record.longSupplier.getAsLong()).isEqualTo(200);
+          assertThat(record.supplierLong().get()).isEqualTo(Long.valueOf(300));
+        }
+      }
+    }
+
+    @Override
+    protected void assertSuppliersHaveUpdatedValues(RecordWithLongs record) {
+      assertThat(record.longSupplier.getAsLong()).isEqualTo(200);
+      assertThat(record.supplierLong().get()).isEqualTo(Long.valueOf(300));
+    }
+  }
+
+  public static class DoublePreferencesTest
+      extends PreferencesRegistryTestCase<DoublePreferencesTest.RecordWithDoubles> {
+    static final String PREFERENCE_NAME = "Doubles";
+    static final String DOUBLE_VALUE_KEY = "Doubles/doubleValue";
+    static final String DOUBLE_SUPPLIER_KEY = "Doubles/doubleSupplier";
+    static final String SUPPLIER_DOUBLE_KEY = "Doubles/supplierDouble";
+
+    public DoublePreferencesTest() {
+      super(PREFERENCE_NAME);
+    }
+
+    /** Test record for testing classes that contain double fields. */
+    private record RecordWithDoubles(
+        double doubleValue, DoubleSupplier doubleSupplier, Supplier<Double> supplierDouble) {
+
+      static RecordWithDoubles withDefaultValues(
+          double doubleValue, double doubleSupplierValue, double supplierDoubleValue) {
+        return new RecordWithDoubles(
+            doubleValue, () -> doubleSupplierValue, () -> supplierDoubleValue);
+      }
+    }
+
+    @Override
+    protected RecordWithDoubles createRecordWithConfiguredDefaults() {
+      return RecordWithDoubles.withDefaultValues(3.14159, 2.71828, 6.28318);
+    }
+
+    @Override
+    protected void assertHasConfiguredDefaults(RecordWithDoubles record) {
+      assertThat(record.doubleValue()).isWithin(EPSILON).of(3.14159);
+      assertThat(record.doubleSupplier.getAsDouble()).isWithin(EPSILON).of(2.71828);
+      assertThat(record.supplierDouble().get()).isWithin(EPSILON).of(6.28318);
+    }
+
+    @Override
+    protected void assertPreferencesHaveConfiguredDefaults() {
+      assertThat(preferenceKeys())
+          .containsExactly(DOUBLE_VALUE_KEY, DOUBLE_SUPPLIER_KEY, SUPPLIER_DOUBLE_KEY);
+      assertThat(Preferences.getDouble(DOUBLE_VALUE_KEY, -1)).isWithin(EPSILON).of(3.14159);
+      assertThat(Preferences.getDouble(DOUBLE_SUPPLIER_KEY, -1)).isWithin(EPSILON).of(2.71828);
+      assertThat(Preferences.getDouble(SUPPLIER_DOUBLE_KEY, -1)).isWithin(EPSILON).of(6.28318);
+    }
+
+    @Override
+    protected void updatePreferenceValues(ValuesKind kind) {
+      switch (kind) {
+        case INITIAL_VALUES -> {
+          Preferences.setDouble(DOUBLE_VALUE_KEY, 1.23);
+          Preferences.setDouble(DOUBLE_SUPPLIER_KEY, 4.56);
+          Preferences.setDouble(SUPPLIER_DOUBLE_KEY, 7.89);
+        }
+        case UPDATED_VALUES -> {
+          Preferences.setDouble(DOUBLE_VALUE_KEY, 10.23);
+          Preferences.setDouble(DOUBLE_SUPPLIER_KEY, 40.56);
+          Preferences.setDouble(SUPPLIER_DOUBLE_KEY, 70.89);
+        }
+      }
+    }
+
+    @Override
+    protected void assertHasUpdatedValues(ValuesKind kind, RecordWithDoubles record) {
+      switch (kind) {
+        case INITIAL_VALUES -> {
+          assertThat(record.doubleValue()).isWithin(EPSILON).of(1.23);
+          assertThat(record.doubleSupplier.getAsDouble()).isWithin(EPSILON).of(4.56);
+          assertThat(record.supplierDouble().get()).isWithin(EPSILON).of(7.89);
+        }
+        case UPDATED_VALUES -> {
+          assertThat(record.doubleValue()).isWithin(EPSILON).of(10.23);
+          assertThat(record.doubleSupplier.getAsDouble()).isWithin(EPSILON).of(40.56);
+          assertThat(record.supplierDouble().get()).isWithin(EPSILON).of(70.89);
+        }
+      }
+    }
+
+    @Override
+    protected void assertSuppliersHaveUpdatedValues(RecordWithDoubles record) {
+      assertThat(record.doubleSupplier.getAsDouble()).isWithin(EPSILON).of(40.56);
+      assertThat(record.supplierDouble().get()).isWithin(EPSILON).of(70.89);
+    }
+  }
+
+  public static class StringPreferencesTest
+      extends PreferencesRegistryTestCase<StringPreferencesTest.RecordWithStrings> {
+    static final String PREFERENCE_NAME = "Strings";
+    static final String STRING_VALUE_KEY = "Strings/stringValue";
+    static final String SUPPLIER_STRING_KEY = "Strings/supplierString";
+
+    public StringPreferencesTest() {
+      super(PREFERENCE_NAME);
+    }
+
+    private record RecordWithStrings(String stringValue, Supplier<String> supplierString) {
+
+      static RecordWithStrings withDefaultValues(String stringValue, String supplierStringValue) {
+        return new RecordWithStrings(stringValue, () -> supplierStringValue);
+      }
+    }
+
+    @Override
+    protected RecordWithStrings createRecordWithConfiguredDefaults() {
+      return RecordWithStrings.withDefaultValues("chicken", "bus");
+    }
+
+    @Override
+    protected void assertHasConfiguredDefaults(RecordWithStrings record) {
+      assertThat(record.stringValue()).isEqualTo("chicken");
+      assertThat(record.supplierString().get()).isEqualTo("bus");
+    }
+
+    @Override
+    protected void assertPreferencesHaveConfiguredDefaults() {
+      assertThat(preferenceKeys()).containsExactly(STRING_VALUE_KEY, SUPPLIER_STRING_KEY);
+      assertThat(Preferences.getString(STRING_VALUE_KEY, "")).isEqualTo("chicken");
+      assertThat(Preferences.getString(SUPPLIER_STRING_KEY, "")).isEqualTo("bus");
+    }
+
+    @Override
+    protected void updatePreferenceValues(ValuesKind kind) {
+      switch (kind) {
+        case INITIAL_VALUES -> {
+          Preferences.setString(STRING_VALUE_KEY, "Gear");
+          Preferences.setString(SUPPLIER_STRING_KEY, "Heads");
+        }
+        case UPDATED_VALUES -> {
+          Preferences.setString(STRING_VALUE_KEY, "Blue");
+          Preferences.setString(SUPPLIER_STRING_KEY, "White");
+        }
+      }
+    }
+
+    @Override
+    protected void assertHasUpdatedValues(ValuesKind kind, RecordWithStrings record) {
+      switch (kind) {
+        case INITIAL_VALUES -> {
+          assertThat(record.stringValue()).isEqualTo("Gear");
+          assertThat(record.supplierString().get()).isEqualTo("Heads");
+        }
+        case UPDATED_VALUES -> {
+          assertThat(record.stringValue()).isEqualTo("Blue");
+          assertThat(record.supplierString().get()).isEqualTo("White");
+        }
+      }
+    }
+
+    @Override
+    protected void assertSuppliersHaveUpdatedValues(RecordWithStrings record) {
+      assertThat(record.supplierString().get()).isEqualTo("White");
+    }
+  }
+
+  public static class RecordPreferencesTest
+      extends PreferencesRegistryTestCase<RecordPreferencesTest.RecordWithRecords> {
+    static final String PREFERENCE_NAME = "Records";
+    static final String recordValueKey = "Records/recordValue";
+    static final String longValueKey = recordValueKey + "/longValue";
+    static final String stringValueKey = recordValueKey + "/stringValue";
+
+    public RecordPreferencesTest() {
+      super(PREFERENCE_NAME);
+    }
+
+    private record RecordWithPrimitives(long longValue, String stringValue) {}
+
+    /** Test record for testing classes that contain record fields. */
+    private record RecordWithRecords(RecordWithPrimitives recordValue) {}
+
+    @Override
+    protected RecordWithRecords createRecordWithConfiguredDefaults() {
+      return new RecordWithRecords(new RecordWithPrimitives(42, "The Answer"));
+    }
+
+    @Override
+    protected void assertHasConfiguredDefaults(RecordWithRecords record) {
+      assertThat(record.recordValue.stringValue()).isEqualTo("The Answer");
+      assertThat(record.recordValue.longValue()).isEqualTo(42);
+    }
+
+    @Override
+    protected void assertPreferencesHaveConfiguredDefaults() {
+      assertThat(preferenceKeys()).containsExactly(stringValueKey, longValueKey);
+      assertThat(Preferences.getString(stringValueKey, "")).isEqualTo("The Answer");
+      assertThat(Preferences.getLong(longValueKey, -1)).isEqualTo(42);
+    }
+
+    @Override
+    protected void updatePreferenceValues(ValuesKind kind) {
+      switch (kind) {
+        case INITIAL_VALUES -> {
+          Preferences.setString(stringValueKey, "Agent");
+          Preferences.setLong(longValueKey, 99);
+        }
+        case UPDATED_VALUES -> {
+          Preferences.setString(stringValueKey, "Gear Heads");
+          Preferences.setLong(longValueKey, 2813);
+        }
+      }
+    }
+
+    @Override
+    protected void assertHasUpdatedValues(ValuesKind kind, RecordWithRecords record) {
+      switch (kind) {
+        case INITIAL_VALUES -> {
+          assertThat(record.recordValue.stringValue()).isEqualTo("Agent");
+          assertThat(record.recordValue.longValue()).isEqualTo(99);
+        }
+        case UPDATED_VALUES -> {
+          assertThat(record.recordValue.stringValue()).isEqualTo("Gear Heads");
+          assertThat(record.recordValue.longValue()).isEqualTo(2813);
+        }
+      }
+    }
+
+    @Override
+    protected void assertSuppliersHaveUpdatedValues(RecordWithRecords record) {
+      // Supplier<Record> is not supported, so nothing to do here.
+    }
+  }
+}

--- a/lib/src/test/java/com/team2813/lib2813/preferences/PreferencesInjectorTest.java
+++ b/lib/src/test/java/com/team2813/lib2813/preferences/PreferencesInjectorTest.java
@@ -6,10 +6,12 @@ import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 
 import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.wpilibj.DataLogManager;
 import edu.wpi.first.wpilibj.Preferences;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.*;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -508,7 +510,7 @@ public final class PreferencesInjectorTest {
       // Assert: Preferences injected
       assertThat(newRecordWithPreferences.recordValue.longValue()).isEqualTo(2813);
       assertThat(newRecordWithPreferences.recordValue.stringValue()).isEqualTo("Gear Heads");
-      ;
+
       assertHasNoChangesSince(preferenceValues);
     }
 
@@ -539,7 +541,7 @@ public final class PreferencesInjectorTest {
       // Assert: Preferences injected
       assertThat(newRecordWithPreferences.recordValue.longValue()).isEqualTo(2813);
       assertThat(newRecordWithPreferences.recordValue.stringValue()).isEqualTo("Gear Heads");
-      ;
+
       assertHasNoChangesSince(preferenceValues);
     }
   }
@@ -555,11 +557,17 @@ public final class PreferencesInjectorTest {
     public void createInjector() {
       String removePrefix = getClass().getCanonicalName() + ".";
       injector = new PreferencesInjector(removePrefix);
-      injector.throwExceptions = true;
-      injector.errorReporter =
+      PersistedConfiguration.throwExceptions = true;
+      PersistedConfiguration.errorReporter =
           message ->
               errorCollector.addError(
                   new AssertionError("Unexpected warning: \"" + message + "\""));
+    }
+
+    @After
+    public void resetTestGlobals() {
+      PersistedConfiguration.throwExceptions = false;
+      PersistedConfiguration.errorReporter = DataLogManager::log;
     }
 
     protected static String keyForFieldName(Class<? extends Record> recordClass, String fieldName) {


### PR DESCRIPTION
Improvements over PreferencesInjector:
- Caller can specify a name for the group of preferences (producing shorter
  preference keys)
- For each registered preference, a sub-table is created using the passed-in
  name (making it easier to browse preferences)
- Methods are static (PreferencesInjector requires either constructing a
  global instance or referencing the static global `DEFAULT_INSTANCE`)

The uniqueness of preference names is enforced by storing the record class
name in network tables via a non-persisted topic.