### PR TITLE
Add PersistedConfiguration.fromPreferences(String, Class)

### DIFF
--- a/lib/src/main/java/com/team2813/lib2813/preferences/PersistedConfiguration.java
+++ b/lib/src/main/java/com/team2813/lib2813/preferences/PersistedConfiguration.java
@@ -459,26 +459,6 @@ public final class PersistedConfiguration {
     errorReporter.accept(message);
   }
 
-  private static <T> T createInstanceWithJavaDefaults(Class<T> clazz)
-      throws ReflectiveOperationException {
-    if (clazz.isPrimitive()) {
-      return clazz.cast(Array.get(Array.newInstance(clazz, 1), 0));
-    }
-    if (Record.class.isAssignableFrom(clazz)) {
-      var components = clazz.getRecordComponents();
-      Object[] params = new Object[components.length];
-      Class<?>[] types = new Class[components.length];
-      int i = 0;
-      for (RecordComponent component : components) {
-        Class<?> type = component.getType();
-        types[i] = type;
-        params[i] = createInstanceWithJavaDefaults(type);
-      }
-      return clazz.getDeclaredConstructor(types).newInstance(params);
-    }
-    throw new IllegalArgumentException("Unsupported type: " + clazz);
-  }
-
   private PersistedConfiguration() {
     throw new AssertionError("Not instantiable");
   }

--- a/lib/src/main/java/com/team2813/lib2813/preferences/PersistedConfiguration.java
+++ b/lib/src/main/java/com/team2813/lib2813/preferences/PersistedConfiguration.java
@@ -21,8 +21,7 @@ import java.util.function.*;
  *
  * <p>Example use:
  *
- * <pre>
- * {@code
+ * <pre>{@code
  * public final class Drive {
  *
  *   public record DriveConfiguration(
@@ -34,8 +33,7 @@ import java.util.function.*;
  *     }
  *   }
  * }
- * }
- * </pre>
+ * }</pre>
  *
  * <p>In the above example, {@code fromPreferences()} would return a record instance with the values
  * populated the "Preferences" NetworkTables table. The keys would be:
@@ -59,8 +57,7 @@ import java.util.function.*;
  *
  * <p>The caller could specify different default values by passing an instance of the record class:
  *
- * <pre>
- * {@code
+ * <pre>{@code
  * public final class Drive {
  *
  *   public record DriveConfiguration(
@@ -74,8 +71,7 @@ import java.util.function.*;
  *     }
  *   }
  * }
- * }
- * </pre>
+ * }</pre>
  *
  * <p>In the above example, {@code fromPreferences()} would return a record instance with the values
  * populated the "Preferences" NetworkTables table. The keys and default values would be:

--- a/lib/src/main/java/com/team2813/lib2813/preferences/PersistedConfiguration.java
+++ b/lib/src/main/java/com/team2813/lib2813/preferences/PersistedConfiguration.java
@@ -317,6 +317,7 @@ public final class PersistedConfiguration {
         defaultValue = Boolean.FALSE;
       }
       Preferences.initBoolean(key, defaultValue);
+      return defaultValue;
     }
     return Preferences.getBoolean(key, false);
   }
@@ -345,6 +346,7 @@ public final class PersistedConfiguration {
         defaultValue = 0;
       }
       Preferences.initInt(key, defaultValue);
+      return defaultValue;
     }
     return Preferences.getInt(key, 0);
   }
@@ -367,6 +369,7 @@ public final class PersistedConfiguration {
         defaultValue = 0L;
       }
       Preferences.initLong(key, defaultValue);
+      return defaultValue;
     }
     return Preferences.getLong(key, 0);
   }
@@ -392,6 +395,7 @@ public final class PersistedConfiguration {
         defaultValue = 0.0;
       }
       Preferences.initDouble(key, defaultValue);
+      return defaultValue;
     }
     return Preferences.getDouble(key, 0);
   }
@@ -417,6 +421,7 @@ public final class PersistedConfiguration {
         defaultValue = "";
       }
       Preferences.initString(key, defaultValue);
+      return defaultValue;
     }
     return Preferences.getString(key, "");
   }

--- a/lib/src/main/java/com/team2813/lib2813/preferences/PersistedConfiguration.java
+++ b/lib/src/main/java/com/team2813/lib2813/preferences/PersistedConfiguration.java
@@ -21,7 +21,8 @@ import java.util.function.*;
  *
  * <p>Example use:
  *
- * {@snippet :
+ * <pre>
+ * {@code :
  * public final class Drive {
  *
  *   public record DriveConfiguration(
@@ -34,6 +35,7 @@ import java.util.function.*;
  *   }
  * }
  * }
+ * </pre>
  *
  * <p>In the above example, {@code fromPreferences()} would return a record instance with the values
  * populated the "Preferences" NetworkTables table. The keys would be:
@@ -57,7 +59,8 @@ import java.util.function.*;
  *
  * <p>The caller could specify different default values by passing an instance of the record class:
  *
- * {@snippet :
+ * <pre>
+ * {@code :
  * public final class Drive {
  *
  *   public record DriveConfiguration(
@@ -72,6 +75,7 @@ import java.util.function.*;
  *   }
  * }
  * }
+ * </pre>
  *
  * <p>In the above example, {@code fromPreferences()} would return a record instance with the values
  * populated the "Preferences" NetworkTables table. The keys and default values would be:

--- a/lib/src/main/java/com/team2813/lib2813/preferences/PersistedConfiguration.java
+++ b/lib/src/main/java/com/team2813/lib2813/preferences/PersistedConfiguration.java
@@ -62,11 +62,11 @@ import java.util.function.*;
  *
  *   public record DriveConfiguration(
  *       boolean addVisionMeasurements, long robotWeight,
- *       DoubleSupplier powerMultiplier) {
+ *       DoubleSupplier maxAngularVelocity) {
  *
  *     public static DriveConfiguration fromPreferences() {
  *       DriveConfiguration defaultConfig = new DriveConfiguration(
- *           true, 1337, () -> 3.14);
+ *           true, 2813, () -> 3.14);
  *       return PersistedConfiguration.fromPreferences("Drive", defaultConfig);
  *     }
  *   }
@@ -78,8 +78,8 @@ import java.util.function.*;
  *
  * <ul>
  *   <li>{@code "Drive/addVisionMeasurements"} (default value: {@code true})
- *   <li>{@code "Drive/robotWeight"} (default value: {@code 1337})
- *   <li>{@code "Drive/powerMultiplier"} (default value: {@code 3.14})
+ *   <li>{@code "Drive/robotWeight"} (default value: {@code 2813})
+ *   <li>{@code "Drive/maxAngularVelocity"} (default value: {@code 3.14})
  * </ul>
  *
  * <p>For record classes with many component values of the same type, it is strongly recommended

--- a/lib/src/main/java/com/team2813/lib2813/preferences/PersistedConfiguration.java
+++ b/lib/src/main/java/com/team2813/lib2813/preferences/PersistedConfiguration.java
@@ -22,7 +22,7 @@ import java.util.function.*;
  * <p>Example use:
  *
  * <pre>
- * {@code :
+ * {@code
  * public final class Drive {
  *
  *   public record DriveConfiguration(
@@ -53,14 +53,14 @@ import java.util.function.*;
  *
  * <ul>
  *   <li>{@code "Drive/addVisionMeasurements"}: {@code false}
- *   <li>{@code "Drive/robotWeight"}: 0
- *   <li>{@code "Drive/powerMultiplier"}: 0.0
+ *   <li>{@code "Drive/robotWeight"}: {@code 0}
+ *   <li>{@code "Drive/powerMultiplier"}: {@code 0.0}
  * </ul>
  *
  * <p>The caller could specify different default values by passing an instance of the record class:
  *
  * <pre>
- * {@code :
+ * {@code
  * public final class Drive {
  *
  *   public record DriveConfiguration(

--- a/lib/src/test/java/com/team2813/lib2813/preferences/PersistedConfigurationTest.java
+++ b/lib/src/test/java/com/team2813/lib2813/preferences/PersistedConfigurationTest.java
@@ -136,7 +136,7 @@ public final class PersistedConfigurationTest {
     protected abstract void assertSuppliersHaveUpdatedValues(T record);
 
     @Test
-    public void withoutExistingPreferences() {
+    public void withoutExistingPreferences_passingRecordInstance() {
       // Arrange
       T recordWithDefaults = createRecordWithConfiguredDefaults();
 
@@ -169,7 +169,7 @@ public final class PersistedConfigurationTest {
     }
 
     @Test
-    public void withoutExistingPreferences_defaultsNotSpecified() {
+    public void withoutExistingPreferences_passingRecordClass() {
       // Act
       var recordWithPreferences =
           PersistedConfiguration.fromPreferences(preferenceName, recordClass);
@@ -199,7 +199,7 @@ public final class PersistedConfigurationTest {
     }
 
     @Test
-    public void withExistingPreferences() {
+    public void withExistingPreferences_passingRecordInstance() {
       // Arrange
       updatePreferenceValues(ValuesKind.INITIAL_VALUES);
       var preferenceValues = preferenceValues();
@@ -232,7 +232,7 @@ public final class PersistedConfigurationTest {
     }
 
     @Test
-    public void withExistingPreferences_defaultsNotSpecified() {
+    public void withExistingPreferences_passingRecordClass() {
       // Arrange
       updatePreferenceValues(ValuesKind.INITIAL_VALUES);
       var preferenceValues = preferenceValues();

--- a/lib/src/test/java/com/team2813/lib2813/preferences/PersistedConfigurationTest.java
+++ b/lib/src/test/java/com/team2813/lib2813/preferences/PersistedConfigurationTest.java
@@ -146,6 +146,8 @@ public final class PersistedConfigurationTest {
 
       // Assert: Preferences injected
       assertHasConfiguredDefaults(recordWithPreferences);
+      // Ensure the suppliers return the same value if called multiple times.
+      assertHasConfiguredDefaults(recordWithPreferences);
 
       // Assert: Default values set
       assertPreferencesHaveConfiguredDefaults();
@@ -162,6 +164,8 @@ public final class PersistedConfigurationTest {
       assertHasUpdatedValues(ValuesKind.UPDATED_VALUES, newRecordWithPreferences);
       assertSuppliersHaveUpdatedValues(recordWithPreferences);
       assertHasNoChangesSince(preferenceValues);
+      // Ensure the suppliers return the same value if called multiple times.
+      assertHasUpdatedValues(ValuesKind.UPDATED_VALUES, newRecordWithPreferences);
     }
 
     @Test
@@ -174,6 +178,8 @@ public final class PersistedConfigurationTest {
       assertHasJavaDefaults(recordWithPreferences);
 
       // Assert: Default values set
+      assertPreferencesHaveJavaDefaults();
+      // Ensure the suppliers return the same value if called multiple times.
       assertPreferencesHaveJavaDefaults();
 
       // Arrange: Update preferences
@@ -188,6 +194,8 @@ public final class PersistedConfigurationTest {
       assertHasUpdatedValues(ValuesKind.UPDATED_VALUES, newRecordWithPreferences);
       assertSuppliersHaveUpdatedValues(recordWithPreferences);
       assertHasNoChangesSince(preferenceValues);
+      // Ensure the suppliers return the same value if called multiple times.
+      assertHasUpdatedValues(ValuesKind.UPDATED_VALUES, newRecordWithPreferences);
     }
 
     @Test
@@ -204,6 +212,8 @@ public final class PersistedConfigurationTest {
       // Assert: Preferences injected
       assertHasUpdatedValues(ValuesKind.INITIAL_VALUES, recordWithPreferences);
       assertHasNoChangesSince(preferenceValues);
+      // Ensure the suppliers return the same value if called multiple times.
+      assertHasUpdatedValues(ValuesKind.INITIAL_VALUES, recordWithPreferences);
 
       // Arrange: Update preferences
       updatePreferenceValues(ValuesKind.UPDATED_VALUES);
@@ -217,6 +227,8 @@ public final class PersistedConfigurationTest {
       assertHasUpdatedValues(ValuesKind.UPDATED_VALUES, newRecordWithPreferences);
       assertSuppliersHaveUpdatedValues(recordWithPreferences);
       assertHasNoChangesSince(preferenceValues);
+      // Ensure the suppliers return the same value if called multiple times.
+      assertHasUpdatedValues(ValuesKind.UPDATED_VALUES, newRecordWithPreferences);
     }
 
     @Test
@@ -232,6 +244,8 @@ public final class PersistedConfigurationTest {
       // Assert: Preferences injected
       assertHasUpdatedValues(ValuesKind.INITIAL_VALUES, recordWithPreferences);
       assertHasNoChangesSince(preferenceValues);
+      // Ensure the suppliers return the same value if called multiple times.
+      assertHasUpdatedValues(ValuesKind.INITIAL_VALUES, recordWithPreferences);
 
       // Arrange: Update preferences
       updatePreferenceValues(ValuesKind.UPDATED_VALUES);
@@ -245,6 +259,8 @@ public final class PersistedConfigurationTest {
       assertHasUpdatedValues(ValuesKind.UPDATED_VALUES, newRecordWithPreferences);
       assertSuppliersHaveUpdatedValues(recordWithPreferences);
       assertHasNoChangesSince(preferenceValues);
+      // Ensure the suppliers return the same value if called multiple times.
+      assertHasUpdatedValues(ValuesKind.UPDATED_VALUES, newRecordWithPreferences);
     }
   }
 
@@ -427,15 +443,11 @@ public final class PersistedConfigurationTest {
         case INITIAL_VALUES -> {
           assertThat(record.intValue()).isEqualTo(101);
           assertThat(record.intSupplier.getAsInt()).isEqualTo(102);
-          assertThat(record.intSupplier.getAsInt()).isEqualTo(102);
-          assertThat(record.supplierInt().get()).isEqualTo(Integer.valueOf(103));
           assertThat(record.supplierInt().get()).isEqualTo(Integer.valueOf(103));
         }
         case UPDATED_VALUES -> {
           assertThat(record.intValue()).isEqualTo(201);
           assertThat(record.intSupplier.getAsInt()).isEqualTo(202);
-          assertThat(record.intSupplier.getAsInt()).isEqualTo(202);
-          assertThat(record.supplierInt().get()).isEqualTo(Integer.valueOf(203));
           assertThat(record.supplierInt().get()).isEqualTo(Integer.valueOf(203));
         }
       }
@@ -444,8 +456,6 @@ public final class PersistedConfigurationTest {
     @Override
     protected void assertSuppliersHaveUpdatedValues(RecordWithInts record) {
       assertThat(record.intSupplier.getAsInt()).isEqualTo(202);
-      assertThat(record.intSupplier.getAsInt()).isEqualTo(202);
-      assertThat(record.supplierInt().get()).isEqualTo(Integer.valueOf(203));
       assertThat(record.supplierInt().get()).isEqualTo(Integer.valueOf(203));
     }
   }

--- a/lib/src/test/java/com/team2813/lib2813/preferences/PersistedConfigurationTest.java
+++ b/lib/src/test/java/com/team2813/lib2813/preferences/PersistedConfigurationTest.java
@@ -30,12 +30,14 @@ public final class PersistedConfigurationTest {
   /** Base class for all nested classes of {@link PersistedConfigurationTest}. */
   abstract static class PreferencesRegistryTestCase<T extends Record> {
     private final String preferenceName;
+    private final Class<T> recordClass;
 
     @Rule public final IsolatedPreferences isolatedPreferences = new IsolatedPreferences();
     @Rule public final ErrorCollector errorCollector = new ErrorCollector();
 
-    protected PreferencesRegistryTestCase(String preferenceName) {
+    protected PreferencesRegistryTestCase(String preferenceName, Class<T> recordClass) {
       this.preferenceName = preferenceName;
+      this.recordClass = recordClass;
     }
 
     @Before
@@ -112,6 +114,12 @@ public final class PersistedConfigurationTest {
      */
     protected abstract void assertPreferencesHaveConfiguredDefaults();
 
+    /** Verifies that all values of the given record equal the Java default value for the type. */
+    protected abstract void assertHasJavaDefaults(T record);
+
+    /** Verifies that all preferences have values equal to the Java default value of the type. */
+    protected abstract void assertPreferencesHaveJavaDefaults();
+
     /** Updates the values of all preferences. */
     protected abstract void updatePreferenceValues(ValuesKind kind);
 
@@ -157,6 +165,32 @@ public final class PersistedConfigurationTest {
     }
 
     @Test
+    public void withoutExistingPreferences_defaultsNotSpecified() {
+      // Act
+      var recordWithPreferences =
+          PersistedConfiguration.fromPreferences(preferenceName, recordClass);
+
+      // Assert: Preferences injected
+      assertHasJavaDefaults(recordWithPreferences);
+
+      // Assert: Default values set
+      assertPreferencesHaveJavaDefaults();
+
+      // Arrange: Update preferences
+      updatePreferenceValues(ValuesKind.UPDATED_VALUES);
+      var preferenceValues = preferenceValues();
+
+      // Act
+      var newRecordWithPreferences =
+          PersistedConfiguration.fromPreferences(preferenceName, recordClass);
+
+      // Assert: Preferences injected
+      assertHasUpdatedValues(ValuesKind.UPDATED_VALUES, newRecordWithPreferences);
+      assertSuppliersHaveUpdatedValues(recordWithPreferences);
+      assertHasNoChangesSince(preferenceValues);
+    }
+
+    @Test
     public void withExistingPreferences() {
       // Arrange
       updatePreferenceValues(ValuesKind.INITIAL_VALUES);
@@ -184,6 +218,34 @@ public final class PersistedConfigurationTest {
       assertSuppliersHaveUpdatedValues(recordWithPreferences);
       assertHasNoChangesSince(preferenceValues);
     }
+
+    @Test
+    public void withExistingPreferences_defaultsNotSpecified() {
+      // Arrange
+      updatePreferenceValues(ValuesKind.INITIAL_VALUES);
+      var preferenceValues = preferenceValues();
+
+      // Act
+      var recordWithPreferences =
+          PersistedConfiguration.fromPreferences(preferenceName, recordClass);
+
+      // Assert: Preferences injected
+      assertHasUpdatedValues(ValuesKind.INITIAL_VALUES, recordWithPreferences);
+      assertHasNoChangesSince(preferenceValues);
+
+      // Arrange: Update preferences
+      updatePreferenceValues(ValuesKind.UPDATED_VALUES);
+      preferenceValues = preferenceValues();
+
+      // Act
+      var newRecordWithPreferences =
+          PersistedConfiguration.fromPreferences(preferenceName, recordClass);
+
+      // Assert: Preferences injected
+      assertHasUpdatedValues(ValuesKind.UPDATED_VALUES, newRecordWithPreferences);
+      assertSuppliersHaveUpdatedValues(recordWithPreferences);
+      assertHasNoChangesSince(preferenceValues);
+    }
   }
 
   @RunWith(Parameterized.class)
@@ -203,7 +265,7 @@ public final class PersistedConfigurationTest {
     }
 
     public BooleanPreferencesTest(boolean defaultValue) {
-      super(PREFERENCE_NAME);
+      super(PREFERENCE_NAME, RecordWithBooleans.class);
       this.defaultValue = defaultValue;
     }
 
@@ -235,6 +297,22 @@ public final class PersistedConfigurationTest {
           .containsExactly(BOOLEAN_VALUE_KEY, BOOLEAN_SUPPLIER_KEY, SUPPLIER_BOOLEAN_KEY);
       for (String key : ALL_KEYS) {
         assertThat(Preferences.getBoolean(key, !defaultValue)).isEqualTo(defaultValue);
+      }
+    }
+
+    @Override
+    protected void assertHasJavaDefaults(RecordWithBooleans record) {
+      assertThat(record.booleanValue()).isFalse();
+      assertThat(record.booleanSupplier().getAsBoolean()).isFalse();
+      assertThat(record.supplierBoolean().get()).isFalse();
+    }
+
+    @Override
+    protected void assertPreferencesHaveJavaDefaults() {
+      assertThat(preferenceKeys())
+          .containsExactly(BOOLEAN_VALUE_KEY, BOOLEAN_SUPPLIER_KEY, SUPPLIER_BOOLEAN_KEY);
+      for (String key : ALL_KEYS) {
+        assertThat(Preferences.getBoolean(key, true)).isFalse();
       }
     }
 
@@ -277,7 +355,7 @@ public final class PersistedConfigurationTest {
     static final String SUPPLIER_INT_KEY = "Integers/supplierInt";
 
     public IntPreferencesTest() {
-      super(PREFERENCE_NAME);
+      super(PREFERENCE_NAME, RecordWithInts.class);
     }
 
     /** Test record for testing classes that contain int fields. */
@@ -309,6 +387,22 @@ public final class PersistedConfigurationTest {
       assertThat(Preferences.getInt(INT_VALUE_KEY, -1)).isEqualTo(1);
       assertThat(Preferences.getInt(INT_SUPPLIER_KEY, -1)).isEqualTo(2);
       assertThat(Preferences.getInt(SUPPLIER_INT_KEY, -1)).isEqualTo(3);
+    }
+
+    @Override
+    protected void assertHasJavaDefaults(RecordWithInts record) {
+      assertThat(record.intValue()).isEqualTo(0);
+      assertThat(record.intSupplier.getAsInt()).isEqualTo(0);
+      assertThat(record.supplierInt().get()).isEqualTo(Integer.valueOf(0));
+    }
+
+    @Override
+    protected void assertPreferencesHaveJavaDefaults() {
+      assertThat(preferenceKeys())
+          .containsExactly(INT_VALUE_KEY, INT_SUPPLIER_KEY, SUPPLIER_INT_KEY);
+      assertThat(Preferences.getInt(INT_VALUE_KEY, -1)).isEqualTo(0);
+      assertThat(Preferences.getInt(INT_SUPPLIER_KEY, -1)).isEqualTo(0);
+      assertThat(Preferences.getInt(SUPPLIER_INT_KEY, -1)).isEqualTo(0);
     }
 
     @Override
@@ -364,7 +458,7 @@ public final class PersistedConfigurationTest {
     static final String SUPPLIER_LONG_KEY = "Longs/supplierLong";
 
     public LongPreferencesTest() {
-      super(PREFERENCE_NAME);
+      super(PREFERENCE_NAME, RecordWithLongs.class);
     }
 
     /** Test record for testing classes that contain long fields. */
@@ -396,6 +490,22 @@ public final class PersistedConfigurationTest {
       assertThat(Preferences.getLong(LONG_VALUE_KEY, -1)).isEqualTo(1);
       assertThat(Preferences.getLong(LONG_SUPPLIER_KEY, -1)).isEqualTo(2);
       assertThat(Preferences.getLong(SUPPLIER_LONG_KEY, -1)).isEqualTo(3);
+    }
+
+    @Override
+    protected void assertHasJavaDefaults(RecordWithLongs record) {
+      assertThat(record.longValue()).isEqualTo(0);
+      assertThat(record.longSupplier.getAsLong()).isEqualTo(0);
+      assertThat(record.supplierLong().get()).isEqualTo(Long.valueOf(0));
+    }
+
+    @Override
+    protected void assertPreferencesHaveJavaDefaults() {
+      assertThat(preferenceKeys())
+          .containsExactly(LONG_VALUE_KEY, LONG_SUPPLIER_KEY, SUPPLIER_LONG_KEY);
+      assertThat(Preferences.getLong(LONG_VALUE_KEY, -1)).isEqualTo(0);
+      assertThat(Preferences.getLong(LONG_SUPPLIER_KEY, -1)).isEqualTo(0);
+      assertThat(Preferences.getLong(SUPPLIER_LONG_KEY, -1)).isEqualTo(0);
     }
 
     @Override
@@ -445,7 +555,7 @@ public final class PersistedConfigurationTest {
     static final String SUPPLIER_DOUBLE_KEY = "Doubles/supplierDouble";
 
     public DoublePreferencesTest() {
-      super(PREFERENCE_NAME);
+      super(PREFERENCE_NAME, RecordWithDoubles.class);
     }
 
     /** Test record for testing classes that contain double fields. */
@@ -478,6 +588,22 @@ public final class PersistedConfigurationTest {
       assertThat(Preferences.getDouble(DOUBLE_VALUE_KEY, -1)).isWithin(EPSILON).of(3.14159);
       assertThat(Preferences.getDouble(DOUBLE_SUPPLIER_KEY, -1)).isWithin(EPSILON).of(2.71828);
       assertThat(Preferences.getDouble(SUPPLIER_DOUBLE_KEY, -1)).isWithin(EPSILON).of(6.28318);
+    }
+
+    @Override
+    protected void assertHasJavaDefaults(RecordWithDoubles record) {
+      assertThat(record.doubleValue()).isWithin(EPSILON).of(0);
+      assertThat(record.doubleSupplier.getAsDouble()).isWithin(EPSILON).of(0);
+      assertThat(record.supplierDouble().get()).isWithin(EPSILON).of(0);
+    }
+
+    @Override
+    protected void assertPreferencesHaveJavaDefaults() {
+      assertThat(preferenceKeys())
+          .containsExactly(DOUBLE_VALUE_KEY, DOUBLE_SUPPLIER_KEY, SUPPLIER_DOUBLE_KEY);
+      assertThat(Preferences.getDouble(DOUBLE_VALUE_KEY, -1)).isWithin(EPSILON).of(0);
+      assertThat(Preferences.getDouble(DOUBLE_SUPPLIER_KEY, -1)).isWithin(EPSILON).of(0);
+      assertThat(Preferences.getDouble(SUPPLIER_DOUBLE_KEY, -1)).isWithin(EPSILON).of(0);
     }
 
     @Override
@@ -526,7 +652,7 @@ public final class PersistedConfigurationTest {
     static final String SUPPLIER_STRING_KEY = "Strings/supplierString";
 
     public StringPreferencesTest() {
-      super(PREFERENCE_NAME);
+      super(PREFERENCE_NAME, RecordWithStrings.class);
     }
 
     private record RecordWithStrings(String stringValue, Supplier<String> supplierString) {
@@ -552,6 +678,19 @@ public final class PersistedConfigurationTest {
       assertThat(preferenceKeys()).containsExactly(STRING_VALUE_KEY, SUPPLIER_STRING_KEY);
       assertThat(Preferences.getString(STRING_VALUE_KEY, "")).isEqualTo("chicken");
       assertThat(Preferences.getString(SUPPLIER_STRING_KEY, "")).isEqualTo("bus");
+    }
+
+    @Override
+    protected void assertHasJavaDefaults(RecordWithStrings record) {
+      assertThat(record.stringValue()).isEmpty();
+      assertThat(record.supplierString().get()).isEmpty();
+    }
+
+    @Override
+    protected void assertPreferencesHaveJavaDefaults() {
+      assertThat(preferenceKeys()).containsExactly(STRING_VALUE_KEY, SUPPLIER_STRING_KEY);
+      assertThat(Preferences.getString(STRING_VALUE_KEY, "default")).isEmpty();
+      assertThat(Preferences.getString(SUPPLIER_STRING_KEY, "default")).isEmpty();
     }
 
     @Override
@@ -596,7 +735,7 @@ public final class PersistedConfigurationTest {
     static final String stringValueKey = recordValueKey + "/stringValue";
 
     public RecordPreferencesTest() {
-      super(PREFERENCE_NAME);
+      super(PREFERENCE_NAME, RecordWithRecords.class);
     }
 
     private record RecordWithPrimitives(long longValue, String stringValue) {}
@@ -620,6 +759,19 @@ public final class PersistedConfigurationTest {
       assertThat(preferenceKeys()).containsExactly(stringValueKey, longValueKey);
       assertThat(Preferences.getString(stringValueKey, "")).isEqualTo("The Answer");
       assertThat(Preferences.getLong(longValueKey, -1)).isEqualTo(42);
+    }
+
+    @Override
+    protected void assertHasJavaDefaults(RecordWithRecords record) {
+      assertThat(record.recordValue.stringValue()).isEmpty();
+      assertThat(record.recordValue.longValue()).isEqualTo(0);
+    }
+
+    @Override
+    protected void assertPreferencesHaveJavaDefaults() {
+      assertThat(preferenceKeys()).containsExactly(stringValueKey, longValueKey);
+      assertThat(Preferences.getString(stringValueKey, "default")).isEmpty();
+      assertThat(Preferences.getLong(longValueKey, -1)).isEqualTo(0);
     }
 
     @Override


### PR DESCRIPTION
This can simplify the code required to make a value configurable, as the
caller does not need to specify default values, create a builder, etc.