### PR TITLE
Improvements to MotorSubsystem

### DIFF
--- a/lib/src/main/java/com/team2813/lib2813/subsystems/MotorSubsystem.java
+++ b/lib/src/main/java/com/team2813/lib2813/subsystems/MotorSubsystem.java
@@ -19,7 +19,7 @@ import java.util.function.Supplier;
 /**
  * Defines PID control over a motor, with values specified by an encoder
  *
- * @param <T> the {@link Supplier<Angle>} type to use positions from.
+ * @param <T> the type of the {@link Supplier<Angle>} used to specify setpoints.
  */
 public abstract class MotorSubsystem<T extends Supplier<Angle>> extends SubsystemBase
     implements Motor, Encoder {
@@ -211,6 +211,7 @@ public abstract class MotorSubsystem<T extends Supplier<Angle>> extends Subsyste
     return encoder.getVelocityMeasure();
   }
 
+  /** Applies the PID output to the motor if this subsystem is enabled. */
   @Override
   public void periodic() {
     if (isEnabled) {
@@ -220,10 +221,10 @@ public abstract class MotorSubsystem<T extends Supplier<Angle>> extends Subsyste
 
   /** A configuration for a MotorSubsystem */
   public static class MotorSubsystemConfiguration {
-    /** The default error of a motor subsystems */
+    /** The default acceptable position error. */
     public static final double DEFAULT_ERROR = 5.0;
 
-    /** The default starting position if one is not defined */
+    /** The default starting position if one is not provided. */
     public static final double DEFAULT_STARTING_POSITION = 0.0;
 
     private ControlMode controlMode;
@@ -235,12 +236,12 @@ public abstract class MotorSubsystem<T extends Supplier<Angle>> extends Subsyste
     private double startingPosition;
 
     /**
-     * Creates a new config for MotorSubsystems. The default acceptable error is {@value
+     * Creates a new configuration for a MotorSubsystems. The default acceptable error is {@value
      * #DEFAULT_ERROR}, the PID constants are set to 0, and the starting position is {@value
      * #DEFAULT_STARTING_POSITION}
      *
-     * @param motor the motor to use
-     * @param encoder the encoder to use
+     * @param motor the motor to control
+     * @param encoder the encoder providing feedback
      */
     public MotorSubsystemConfiguration(Motor motor, Encoder encoder) {
       this.motor = Objects.requireNonNull(motor, "motor should not be null");
@@ -257,7 +258,7 @@ public abstract class MotorSubsystem<T extends Supplier<Angle>> extends Subsyste
      * default acceptable error is {@value #DEFAULT_ERROR}, the PID constants are set to 0, and the
      * starting position is {@value #DEFAULT_STARTING_POSITION}
      *
-     * @param motor the motor to use that also supports an encoder
+     * @param motor the integrated motor controller
      */
     public MotorSubsystemConfiguration(PIDMotor motor) {
       this(motor, motor);
@@ -323,6 +324,7 @@ public abstract class MotorSubsystem<T extends Supplier<Angle>> extends Subsyste
       return startingPosition(startingPositionSupplier.get());
     }
 
+    /** Sets the acceptable position error. */
     public MotorSubsystemConfiguration acceptableError(double error) {
       this.acceptableError = error;
       return this;

--- a/lib/src/main/java/com/team2813/lib2813/subsystems/MotorSubsystem.java
+++ b/lib/src/main/java/com/team2813/lib2813/subsystems/MotorSubsystem.java
@@ -167,31 +167,34 @@ public abstract class MotorSubsystem<T extends Supplier<Angle>> extends Subsyste
   }
 
   @Override
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public double position() {
     return encoder.position();
   }
 
+  @Override
   public Angle getPositionMeasure() {
     return encoder.getPositionMeasure();
   }
 
   @Override
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public void setPosition(double position) {
     encoder.setPosition(position);
   }
 
+  @Override
   public void setPosition(Angle position) {
     encoder.setPosition(position);
   }
 
   @Override
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public double getVelocity() {
     return encoder.getVelocity();
   }
 
+  @Override
   public AngularVelocity getVelocityMeasure() {
     return encoder.getVelocityMeasure();
   }

--- a/lib/src/main/java/com/team2813/lib2813/subsystems/MotorSubsystem.java
+++ b/lib/src/main/java/com/team2813/lib2813/subsystems/MotorSubsystem.java
@@ -101,7 +101,7 @@ public abstract class MotorSubsystem<T extends Supplier<Angle>> extends Subsyste
 
   public void disable() {
     isEnabled = false;
-    useOutput(0, 0);
+    motor.set(controlMode, 0);
   }
 
   /**

--- a/lib/src/main/java/com/team2813/lib2813/subsystems/MotorSubsystem.java
+++ b/lib/src/main/java/com/team2813/lib2813/subsystems/MotorSubsystem.java
@@ -50,7 +50,7 @@ public abstract class MotorSubsystem<T extends Supplier<Angle>> extends Subsyste
    *
    * @param position the position to go to.
    */
-  public void setSetpoint(T position) {
+  public final void setSetpoint(T position) {
     if (!isEnabled()) {
       enable();
     }
@@ -68,12 +68,12 @@ public abstract class MotorSubsystem<T extends Supplier<Angle>> extends Subsyste
   }
 
   /** Returns the current setpoint as an angle. */
-  public Angle getSetpoint() {
+  public final Angle getSetpoint() {
     return rotationUnit.of(controller.getSetpoint());
   }
 
   /** Determines if the motor is at the current setpoint, within the acceptable error. */
-  public boolean atPosition() {
+  public final boolean atPosition() {
     return Math.abs(getMeasurement() - controller.getSetpoint()) <= acceptableError;
   }
 
@@ -83,7 +83,7 @@ public abstract class MotorSubsystem<T extends Supplier<Angle>> extends Subsyste
    * <p>Additionally, this method disables PID control of the subsystem
    */
   @Override
-  public void set(ControlMode mode, double demand, double feedForward) {
+  public final void set(ControlMode mode, double demand, double feedForward) {
     if (isEnabled()) {
       disable();
     }
@@ -91,15 +91,27 @@ public abstract class MotorSubsystem<T extends Supplier<Angle>> extends Subsyste
   }
 
   @Override
-  public Current getAppliedCurrent() {
+  public final Current getAppliedCurrent() {
     return motor.getAppliedCurrent();
   }
 
-  public void enable() {
+  /**
+   * Enables the motor
+   *
+   * <p>The motor voltage will be periodically updated to move the motor towards the current
+   * setupoint.
+   */
+  public final void enable() {
     isEnabled = true;
   }
 
-  public void disable() {
+  /**
+   * Stops the motor.
+   *
+   * <p>The motor voltage will be set to zero, and the motor will not adjust to move towards the
+   * current setpoint.
+   */
+  public final void disable() {
     isEnabled = false;
     motor.set(controlMode, 0);
   }
@@ -109,7 +121,7 @@ public abstract class MotorSubsystem<T extends Supplier<Angle>> extends Subsyste
    *
    * @return Whether the controller is enabled.
    */
-  public boolean isEnabled() {
+  public final boolean isEnabled() {
     return isEnabled;
   }
 
@@ -120,7 +132,7 @@ public abstract class MotorSubsystem<T extends Supplier<Angle>> extends Subsyste
    * the provided value.
    */
   @Override
-  public void set(ControlMode mode, double demand) {
+  public final void set(ControlMode mode, double demand) {
     isEnabled = false;
     motor.set(mode, demand);
   }
@@ -162,7 +174,7 @@ public abstract class MotorSubsystem<T extends Supplier<Angle>> extends Subsyste
     return output;
   }
 
-  protected double getMeasurement() {
+  protected final double getMeasurement() {
     return encoder.getPositionMeasure().in(rotationUnit);
   }
 
@@ -173,7 +185,7 @@ public abstract class MotorSubsystem<T extends Supplier<Angle>> extends Subsyste
   }
 
   @Override
-  public Angle getPositionMeasure() {
+  public final Angle getPositionMeasure() {
     return encoder.getPositionMeasure();
   }
 
@@ -184,7 +196,7 @@ public abstract class MotorSubsystem<T extends Supplier<Angle>> extends Subsyste
   }
 
   @Override
-  public void setPosition(Angle position) {
+  public final void setPosition(Angle position) {
     encoder.setPosition(position);
   }
 
@@ -195,7 +207,7 @@ public abstract class MotorSubsystem<T extends Supplier<Angle>> extends Subsyste
   }
 
   @Override
-  public AngularVelocity getVelocityMeasure() {
+  public final AngularVelocity getVelocityMeasure() {
     return encoder.getVelocityMeasure();
   }
 


### PR DESCRIPTION
- Do not clamp output in `disable()`
- Add `setSetpointCommand()`
- Add `clampOutput()` protected method
- Deprecate `useOutput(double, double)`
- Remove `setpoint` field (instead, get from the controller)
- Add missing `@Override` annotations
- Mark many methods as final
- Optionally publish to NetworkTables (#47)