### PR TITLE
Call NetworkTableInstance.waitForListenerQueue() before close()

### DIFF
--- a/lib/src/test/java/com/team2813/lib2813/preferences/IsolatedPreferences.java
+++ b/lib/src/test/java/com/team2813/lib2813/preferences/IsolatedPreferences.java
@@ -21,6 +21,7 @@ public final class IsolatedPreferences extends ExternalResource {
   protected void before() {
     NetworkTableInstance.getDefault();
     tempInstance = NetworkTableInstance.create();
+    tempInstance.startLocal();
     Preferences.setNetworkTableInstance(tempInstance);
   }
 


### PR DESCRIPTION
This works around a race condition where a listener registered by Preferences
was called after the NetworkTableInstance was closed.

Also call `NetworkTableInstance.startLocal()` so that `networktables.json` is not read.