### PR TITLE
Store PersistedConfiguration record registry outside of /Preferences

### DIFF
--- a/lib/src/main/java/com/team2813/lib2813/preferences/PersistedConfiguration.java
+++ b/lib/src/main/java/com/team2813/lib2813/preferences/PersistedConfiguration.java
@@ -96,6 +96,7 @@ import java.util.function.*;
  */
 public final class PersistedConfiguration {
   static final String REGISTERED_CLASSES_NETWORK_TABLE_KEY = "PersistedConfiguration/registry";
+  private static boolean deletedLegacyKeys = false;
 
   // The below package-scope fields are for the self-tests.
   static boolean throwExceptions = false;
@@ -160,6 +161,7 @@ public final class PersistedConfiguration {
 
   private static <T extends Record> T fromPreferences(
       String preferenceName, Class<T> recordClass, T configWithDefaults) {
+    deleteLegacyKeys();
     NetworkTableInstance ntInstance = NetworkTableInstance.getDefault();
     validatePreferenceName(preferenceName);
     verifyNotRegisteredToAnotherClass(ntInstance, preferenceName, recordClass);
@@ -454,6 +456,20 @@ public final class PersistedConfiguration {
     }
 
     return () -> factory.create(component, key, null, false);
+  }
+
+  private static void deleteLegacyKeys() {
+    if (!deletedLegacyKeys) {
+      // Preferences installs a listener that makes all new topics persistent. The ".registeredTo"
+      // topics used to be placed under /Preferences, so could have been persisted. They are now
+      // written under a different top-level table. Delete the topics created by the previous code.
+      for (var key : Preferences.getKeys()) {
+        if (key.endsWith(".registeredTo")) {
+          Preferences.remove(key);
+        }
+      }
+      deletedLegacyKeys = true;
+    }
   }
 
   private static void warn(String format, Object... args) {

--- a/lib/src/main/java/com/team2813/lib2813/preferences/PersistedConfiguration.java
+++ b/lib/src/main/java/com/team2813/lib2813/preferences/PersistedConfiguration.java
@@ -95,6 +95,8 @@ import java.util.function.*;
  * @since 2.0.0
  */
 public final class PersistedConfiguration {
+  static final String REGISTERED_CLASSES_NETWORK_TABLE_KEY = "PersistedConfiguration/registry";
+
   // The below package-scope fields are for the self-tests.
   static boolean throwExceptions = false;
   static Consumer<String> errorReporter = DataLogManager::log;
@@ -191,10 +193,11 @@ public final class PersistedConfiguration {
       recordName = recordClass.getName();
     }
 
-    NetworkTable preferencesTable = ntInstance.getTable("Preferences");
-    NetworkTableEntry entry = preferencesTable.getEntry(name + "/.registeredTo");
+    NetworkTable registeredClassesTable = ntInstance.getTable(REGISTERED_CLASSES_NETWORK_TABLE_KEY);
+    NetworkTableEntry entry = registeredClassesTable.getEntry(name);
     if (!entry.exists()) {
       entry.setString(recordName);
+      entry.clearPersistent();
     } else {
       String registeredTo = entry.getString("");
       if (!recordName.equals(registeredTo)) {
@@ -203,7 +206,6 @@ public final class PersistedConfiguration {
                 "Preference with name '%s' already registered to %s", name, registeredTo));
       }
     }
-    entry.clearPersistent();
   }
 
   private static <T> T createFromPreferences(

--- a/lib/src/test/java/com/team2813/lib2813/preferences/PersistedConfigurationTest.java
+++ b/lib/src/test/java/com/team2813/lib2813/preferences/PersistedConfigurationTest.java
@@ -2,6 +2,7 @@ package com.team2813.lib2813.preferences;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.team2813.lib2813.preferences.PersistedConfiguration.REGISTERED_CLASSES_NETWORK_TABLE_KEY;
 import static java.util.stream.Collectors.toMap;
 import static org.junit.Assert.assertThrows;
 
@@ -155,10 +156,10 @@ public final class PersistedConfigurationTest {
           .hasMessageThat()
           .containsMatch("Preference with name '" + preferenceName + "' already registered");
 
-      // Assert: .registeredTo topic added, and is not persistent
+      // Assert: topic added under "/PersistedConfiguration", and is not persistent
       NetworkTable table =
-          NetworkTableInstance.getDefault().getTable("Preferences").getSubTable(preferenceName);
-      NetworkTableEntry entry = table.getEntry(".registeredTo");
+          NetworkTableInstance.getDefault().getTable(REGISTERED_CLASSES_NETWORK_TABLE_KEY);
+      NetworkTableEntry entry = table.getEntry(preferenceName);
       assertThat(entry.exists()).isTrue();
       assertThat(entry.isPersistent()).isFalse();
       assertThat(entry.getType()).isEqualTo(NetworkTableType.kString);


### PR DESCRIPTION
This change moves the NetworkTables keys which store which PersistedConfiguration names map to which record classes outside of /Preferences.

As of the 2025 WPILib code, Preferences has a listener that updates all new topics to be persistent (for backwards compatibility of old dashboards; see https://github.com/wpilibsuite/allwpilib/commit/87fc49c66). Due to this, we cannot store data that should not be persistent under /Preferences without risking a race condition where the topic is later marked as persistent.