### PR TITLE
Update MotorSubsystem to implement Motor.getAppliedCurrent()

### DIFF
--- a/lib/src/main/java/com/team2813/lib2813/subsystems/MotorSubsystem.java
+++ b/lib/src/main/java/com/team2813/lib2813/subsystems/MotorSubsystem.java
@@ -9,6 +9,7 @@ import edu.wpi.first.units.AngleUnit;
 import edu.wpi.first.units.Units;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
+import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -74,6 +75,11 @@ public abstract class MotorSubsystem<T extends Supplier<Angle>> extends Subsyste
       disable();
     }
     motor.set(mode, demand, feedForward);
+  }
+
+  @Override
+  public Current getAppliedCurrent() {
+    return motor.getAppliedCurrent();
   }
 
   public void enable() {


### PR DESCRIPTION
This will remove duplication in the current subclasses in Robot2025.