### PR TITLE
Move FakePIDMotor from :lib to :testing

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -20,11 +20,11 @@ dependencies {
 
     testImplementation(platform('org.junit:junit-bom:5.13.1'))
     testImplementation('org.junit.jupiter:junit-jupiter')
-    testImplementation 'org.mockito:mockito-core:5.14.2'
+    testImplementation('org.mockito:mockito-core:5.14.2')
+    testImplementation('com.google.truth:truth:1.4.4')
     testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testRuntimeOnly('org.junit.vintage:junit-vintage-engine')
     testImplementation 'junit:junit:4.13.2'
-    implementation 'com.google.truth:truth:1.4.4'//needed for FakePIDMotor
     testImplementation project(':testing')
     compileOnly 'com.google.auto.value:auto-value-annotations:1.11.0'
     annotationProcessor 'com.google.auto.value:auto-value:1.11.0'

--- a/lib/src/test/java/com/team2813/lib2813/subsystems/ParameterizedIntakeSubsystemTest.java
+++ b/lib/src/test/java/com/team2813/lib2813/subsystems/ParameterizedIntakeSubsystemTest.java
@@ -6,9 +6,9 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.team2813.lib2813.control.ControlMode;
 import com.team2813.lib2813.control.PIDMotor;
+import com.team2813.lib2813.testing.FakePIDMotor;
 import com.team2813.lib2813.testing.junit.jupiter.CommandTester;
 import com.team2813.lib2813.testing.junit.jupiter.WPILibExtension;
-import com.team2813.lib2813.util.FakePIDMotor;
 import edu.wpi.first.wpilibj2.command.Command;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation 'com.google.truth:truth:1.4.4'
     implementation(platform('org.junit:junit-bom:5.13.1'))
     implementation('org.junit.jupiter:junit-jupiter')
+    implementation project(':lib')
     nativeDebug wpi.java.deps.wpilibJniDebug(wpi.platforms.desktop)
     nativeDebug wpi.java.vendor.jniDebug(wpi.platforms.desktop)
     simulationDebug wpi.sim.enableDebug()

--- a/testing/src/main/java/com/team2813/lib2813/testing/FakePIDMotor.java
+++ b/testing/src/main/java/com/team2813/lib2813/testing/FakePIDMotor.java
@@ -1,4 +1,4 @@
-package com.team2813.lib2813.util;
+package com.team2813.lib2813.testing;
 
 import com.google.common.truth.Truth;
 import com.team2813.lib2813.control.ControlMode;


### PR DESCRIPTION
This reduces the number of dependencies pulled in by :lib, which reduces how
much code has to be deployed to the robot.