### PR TITLE
Add getters for 'demand' and 'controlMode' in FakeMotor

### DIFF
--- a/lib/src/test/java/com/team2813/lib2813/subsystems/ParameterizedIntakeSubsystemTest.java
+++ b/lib/src/test/java/com/team2813/lib2813/subsystems/ParameterizedIntakeSubsystemTest.java
@@ -52,7 +52,7 @@ public final class ParameterizedIntakeSubsystemTest {
 
       commandTester.runUntilComplete(command);
 
-      assertThat(fakeMotor.demand).isWithin(0.01).of(params.intakeDemand());
+      assertThat(fakeMotor.getDemand()).isWithin(0.01).of(params.intakeDemand());
     }
   }
 
@@ -80,7 +80,7 @@ public final class ParameterizedIntakeSubsystemTest {
 
       commandTester.runUntilComplete(command);
 
-      assertThat(fakeMotor.demand).isWithin(0.01).of(params.outtakeDemand());
+      assertThat(fakeMotor.getDemand()).isWithin(0.01).of(params.outtakeDemand());
     }
   }
 
@@ -101,6 +101,6 @@ public final class ParameterizedIntakeSubsystemTest {
   }
 
   private void assertMotorIsRunning() {
-    assertThat(fakeMotor.demand).isNotWithin(0.01).of(0.0);
+    assertThat(fakeMotor.getDemand()).isNotWithin(0.01).of(0.0);
   }
 }

--- a/testing/src/main/java/com/team2813/lib2813/testing/FakeMotor.java
+++ b/testing/src/main/java/com/team2813/lib2813/testing/FakeMotor.java
@@ -24,6 +24,19 @@ public class FakeMotor implements Motor {
   public Resistance resistance = Resistance.ofBaseUnits(0.025f, Units.Ohms);
   private ControlMode controlMode = ControlMode.VOLTAGE;
 
+  /** Gets the most recently applied demand value for this motor. */
+  public final double getDemand() {
+    return demand;
+  }
+
+  /**
+   * Gets the control mode used for the most recent time the demand value was updated for this
+   * motor.
+   */
+  public final ControlMode getControlMode() {
+    return controlMode;
+  }
+
   /**
    * Gets the current voltage being applied to the motor.
    *


### PR DESCRIPTION
This is in preparation for making the 'demand' field package-scope. Now that FakeMotor has an 'isStopped' field, allowing code outside of FakeMotor to directly update the value is error-prone.