### PR TITLE
Remove usages of Command.schedule()

### DIFF
--- a/testing/src/main/java/com/team2813/lib2813/testing/junit/jupiter/WPILibExtension.java
+++ b/testing/src/main/java/com/team2813/lib2813/testing/junit/jupiter/WPILibExtension.java
@@ -89,7 +89,7 @@ public final class WPILibExtension
       ParameterContext parameterContext, ExtensionContext extensionContext) {
     return command -> {
       CommandScheduler scheduler = CommandScheduler.getInstance();
-      command.schedule();
+      scheduler.schedule(command);
       do {
         scheduler.run();
       } while (scheduler.isScheduled(command));


### PR DESCRIPTION
In WPILib v2026 it will be deprecated (see
https://github.com/wpilibsuite/allwpilib/pull/7072).