### PR TITLE
Make Javadoc link to other libraries

### DIFF
--- a/buildSrc/src/main/groovy/java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/java-common-conventions.gradle
@@ -106,3 +106,14 @@ spotless {
         formatAnnotations()  // fix formatting of type annotations
     }
 }
+
+javadoc {
+    options {
+        // CTRE (Phoenix 5 & 6)
+        links += "https://api.ctr-electronics.com/phoenix6/release/java/"
+        // WPILib
+        links += "https://github.wpilib.org/allwpilib/docs/2027/java/"
+        // REVLib
+        links += "https://codedocs.revrobotics.com/java/"
+    }
+}


### PR DESCRIPTION
Adds javadoc arguments to allow linking to the javadoc for the following libraries:
* WPILib
* REVLib
* Phoenix 5 & 6

The javadoc for the release version of each library is linked, since none of them have javadoc for specific versions.