### PR TITLE
Made methods non final, so we can override them

### DIFF
--- a/lib/src/main/java/com/team2813/lib2813/subsystems/MotorSubsystem.java
+++ b/lib/src/main/java/com/team2813/lib2813/subsystems/MotorSubsystem.java
@@ -86,7 +86,7 @@ public abstract class MotorSubsystem<T extends Supplier<Angle>> extends Subsyste
    *
    * @param setpoint the position to go to.
    */
-  protected Command setSetpointCommand(T setpoint) {
+  public final Command setSetpointCommand(T setpoint) {
     return new InstantCommand(() -> this.setSetpoint(setpoint), this);
   }
 
@@ -96,7 +96,7 @@ public abstract class MotorSubsystem<T extends Supplier<Angle>> extends Subsyste
   }
 
   /** Determines if the motor is at the current setpoint, within the acceptable error. */
-  public boolean atPosition() {
+  public final boolean atPosition() {
     return Math.abs(getMeasurement() - controller.getSetpoint()) <= acceptableError;
   }
 


### PR DESCRIPTION
We need them overridable for the arm code.
Mainly because we need to implement a way to move to an arm position based on what position we are currently.
```
if (given_position in current_position.safe_positions_to_move_to) { 
  move(given_position)
} else { dont_move() }
```

This could theoretically be achieved with a helper method checking the safety of a given position, but I would rather the setSetpoint() do this for the assurance that someone doesn't call setSetpoint() directly, skipping the safety check.