### PR TITLE
Add Motor.stopMotor() and deprecate Motor.disable()

### DIFF
--- a/lib/src/main/java/com/team2813/lib2813/control/Motor.java
+++ b/lib/src/main/java/com/team2813/lib2813/control/Motor.java
@@ -45,6 +45,22 @@ public interface Motor {
    */
   Current getAppliedCurrent();
 
-  /** Stops the motor. */
-  void disable();
+  /**
+   * Stops the motor.
+   *
+   * @deprecated Use {@link #stopMotor()}.
+   */
+  @Deprecated
+  default void disable() {
+    stopMotor();
+  }
+
+  /**
+   * Stops the motor.
+   *
+   * @since 2.0.0
+   */
+  default void stopMotor() {
+    set(ControlMode.VOLTAGE, 0);
+  }
 }

--- a/lib/src/main/java/com/team2813/lib2813/control/motors/SparkMaxWrapper.java
+++ b/lib/src/main/java/com/team2813/lib2813/control/motors/SparkMaxWrapper.java
@@ -97,7 +97,7 @@ public class SparkMaxWrapper implements PIDMotor {
   }
 
   @Override
-  public void disable() {
+  public void stopMotor() {
     motor.stopMotor();
   }
 

--- a/lib/src/main/java/com/team2813/lib2813/control/motors/TalonFXWrapper.java
+++ b/lib/src/main/java/com/team2813/lib2813/control/motors/TalonFXWrapper.java
@@ -202,8 +202,8 @@ public class TalonFXWrapper implements PIDMotor {
    * @see TalonFXWrapper#setNeutralMode(NeutralModeValue)
    */
   @Override
-  public void disable() {
-    motor.disable();
+  public void stopMotor() {
+    motor.stopMotor();
   }
 
   @Override

--- a/lib/src/main/java/com/team2813/lib2813/subsystems/MotorSubsystem.java
+++ b/lib/src/main/java/com/team2813/lib2813/subsystems/MotorSubsystem.java
@@ -142,9 +142,7 @@ public abstract class MotorSubsystem<T extends Supplier<Angle>> extends Subsyste
    */
   @Override
   public void set(ControlMode mode, double demand, double feedForward) {
-    if (isEnabled()) {
-      disable();
-    }
+    isEnabled = false;
     motor.set(mode, demand, feedForward);
   }
 
@@ -154,7 +152,7 @@ public abstract class MotorSubsystem<T extends Supplier<Angle>> extends Subsyste
   }
 
   /**
-   * Engages the PID Controller.
+   * Engages the PID controller.
    *
    * <p>The motor voltage will be periodically updated to move the motor towards the current
    * setpoint.
@@ -172,9 +170,10 @@ public abstract class MotorSubsystem<T extends Supplier<Angle>> extends Subsyste
    * <p>The motor voltage will be set to zero, and the motor will not adjust to move towards the
    * current setpoint.
    */
-  public void disable() {
+  @Override
+  public void stopMotor() {
     isEnabled = false;
-    motor.disable();
+    motor.stopMotor();
   }
 
   /**

--- a/testing/src/main/java/com/team2813/lib2813/testing/FakeMotor.java
+++ b/testing/src/main/java/com/team2813/lib2813/testing/FakeMotor.java
@@ -81,7 +81,7 @@ public class FakeMotor implements Motor {
   }
 
   @Override
-  public void disable() {
+  public void stopMotor() {
     if (controlMode != ControlMode.MOTION_MAGIC) {
       set(controlMode, 0);
     }


### PR DESCRIPTION
The name "disable" is confusing. For classes that implement PIDMotor, it could mean stopping the motor or disabling PID control.