### PR TITLE
Attempt to fix crashes in NetworkTableInstance.close()

### DIFF
--- a/lib/src/test/java/com/team2813/lib2813/preferences/IsolatedPreferences.java
+++ b/lib/src/test/java/com/team2813/lib2813/preferences/IsolatedPreferences.java
@@ -24,7 +24,7 @@ import org.junit.rules.ExternalResource;
  * A JUnit rule that ensures that changes to preferences done by a test are not leaked out to other
  * tests.
  */
-public final class IsolatedPreferences extends ExternalResource {
+final class IsolatedPreferences extends ExternalResource {
   private NetworkTableInstance tempInstance;
 
   /** Gets the {@link NetworkTable} that contains the preference values. */
@@ -42,9 +42,9 @@ public final class IsolatedPreferences extends ExternalResource {
 
   @Override
   protected void after() {
-    if (!tempInstance.waitForListenerQueue(.1)) {
+    if (!tempInstance.waitForListenerQueue(.2)) {
       System.err.println(
-          "Timed out waiting for the NetworkTableInstance listener queue to empty (waited 100ms);"
+          "Timed out waiting for the NetworkTableInstance listener queue to empty (waited 200ms);"
               + " JVM may crash");
     }
     Preferences.setNetworkTableInstance(NetworkTableInstance.getDefault());

--- a/testing/src/main/java/com/team2813/lib2813/testing/junit/jupiter/IsolatedNetworkTablesExtension.java
+++ b/testing/src/main/java/com/team2813/lib2813/testing/junit/jupiter/IsolatedNetworkTablesExtension.java
@@ -50,16 +50,16 @@ public final class IsolatedNetworkTablesExtension
   @Override
   public void afterEach(ExtensionContext context) {
     // If this extension created a temporary NetworkTableInstance, close it.
-    var ntInstance = NETWORK_TABLE_INSTANCE_KEY.get(getStore(context));
+    var ntInstance = NETWORK_TABLE_INSTANCE_KEY.remove(getStore(context));
     if (ntInstance != null) {
       // Clear out the listener queue before destroying our temporary NetworkTableInstance.
       //
       // This works around a race condition in WPILib where a listener registered by Preferences can
       // be called after the NetworkTableInstance was closed (see
       // https://github.com/wpilibsuite/allwpilib/issues/8215).
-      if (!ntInstance.waitForListenerQueue(.1)) {
+      if (!ntInstance.waitForListenerQueue(.2)) {
         System.err.println(
-            "Timed out waiting for the NetworkTableInstance listener queue to empty (waited 100ms);"
+            "Timed out waiting for the NetworkTableInstance listener queue to empty (waited 200ms);"
                 + " JVM may crash");
       }
 


### PR DESCRIPTION
- Increase timeouts in calls to `waitForListenerQueue()`
- Update `IsolatedNetworkTablesExtension.afterEach()` to remove the instance
  from the store (so JUnit does not try to close it)

The crashes are nondeterministic, so it's hard to tell if these changes will
eliminate the crashes in our GitHub action runs.