### PR TITLE
Rename addEstimatedRobotPose() to acceptEstimatedRobotPose()

### DIFF
--- a/vision/src/main/java/com/team2813/lib2813/vision/MultiPhotonPoseEstimator.java
+++ b/vision/src/main/java/com/team2813/lib2813/vision/MultiPhotonPoseEstimator.java
@@ -394,7 +394,7 @@ public class MultiPhotonPoseEstimator implements AutoCloseable {
               .flatMap(Optional::stream) // Convert Stream<Optional<P>> -> Stream<P>
               .toList();
 
-      poses.forEach(poseEstimateConsumer::addEstimatedRobotPose);
+      poses.forEach(poseEstimateConsumer::acceptEstimatedRobotPose);
       cameraWrapper.robotPosePublisher.publish(poses);
     }
   }

--- a/vision/src/main/java/com/team2813/lib2813/vision/PoseEstimateConsumer.java
+++ b/vision/src/main/java/com/team2813/lib2813/vision/PoseEstimateConsumer.java
@@ -25,5 +25,5 @@ public interface PoseEstimateConsumer {
    *
    * @param estimatedPose The estimated robot positions.
    */
-  void addEstimatedRobotPose(EstimatedRobotPose estimatedPose);
+  void acceptEstimatedRobotPose(EstimatedRobotPose estimatedPose);
 }


### PR DESCRIPTION
The new naming is more consistent with `java.util.function.Consumer`