### PR TITLE
Hacks to avoid SIGSEGV in tests that call Preferences.setNetworkTableInstance()

### DIFF
--- a/lib/src/test/java/com/team2813/lib2813/preferences/IsolatedPreferences.java
+++ b/lib/src/test/java/com/team2813/lib2813/preferences/IsolatedPreferences.java
@@ -62,7 +62,8 @@ final class IsolatedPreferences extends ExternalResource {
   }
 
   /**
-   * Removes the listener installed by Preferences.setNetworkTableInstance.
+   * Removes the listener installed by {@link
+   * Preferences#setNetworkTableInstance(NetworkTableInstance)}.
    *
    * <p>The listener is a constant source of SIGSEGVs in our GitHub test actions.
    */

--- a/testing/src/main/java/com/team2813/lib2813/testing/junit/jupiter/IsolatedNetworkTablesExtension.java
+++ b/testing/src/main/java/com/team2813/lib2813/testing/junit/jupiter/IsolatedNetworkTablesExtension.java
@@ -111,7 +111,8 @@ public final class IsolatedNetworkTablesExtension
   }
 
   /**
-   * Removes the listener installed by Preferences.setNetworkTableInstance.
+   * Removes the listener installed by {@link
+   * Preferences#setNetworkTableInstance(NetworkTableInstance)}.
    *
    * <p>The listener is a constant source of SIGSEGVs in our GitHub test actions.
    */


### PR DESCRIPTION
Includes the following changes:
- Close the `Listener` installed by `Preferences.setNetworkTableInstance()`
- Do not close the previous `NetworkTableInstance` if the queue cannot be
  flushed
- Remove call to `NetworkTableInstance.startLocal()`