### PR TITLE
Do a full depth clone

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,7 +1,6 @@
 name: Build Gradle project
 
 on: push
-fetch-depth: 0
 
 jobs:
   build-gradle-project:
@@ -9,6 +8,8 @@ jobs:
     steps:
     - name: Checkout project sources
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:


### PR DESCRIPTION
Some issues have been popping up with spotless throwing errors in CI and not on local clones, even if `origin/main` is up-to-date. So, instead of doing a shallow clone, just do a full-depth clone like the spotless devs recommend in their [docs](https://github.com/diffplug/spotless/tree/main/plugin-gradle#using-ratchetfrom-on-ci-systems). We could change this to do a full fetch, but it is probably just simpler to do a non-shallow clone. 

This also updates the action for setting up gradle (which among other things verifies the integrity of the gradle wrapper jar)