### PR TITLE
Remove outdated note in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@
 
 ### Updating your dependencies
 
-> [!NOTE]
-> The lib2813 jars are not yet published to Maven Central. For the time being, you need to publish
-> them to Maven Local. See [the Contributing page](CONTRIBUTING.md#publishing-to-maven-local) for details.
-
 In your project's "gradle" directory, create a file named `libs.versions.toml` with the following content:
 
 ```toml


### PR DESCRIPTION
The note that the jars are not on maven central is no longer accurate, as they are on maven central. So, this note should be removed