### PR TITLE
Reduce SIGSEGVs in tests that use ProvideUniqueNetworkTableInstance

### DIFF
--- a/core/src/test/java/com/team2813/lib2813/preferences/PersistedConfigurationTest.java
+++ b/core/src/test/java/com/team2813/lib2813/preferences/PersistedConfigurationTest.java
@@ -48,14 +48,13 @@ import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /** Tests for {@link PersistedConfiguration}. */
-@Execution(ExecutionMode.SAME_THREAD) // Test updates static state
 @ProvideUniqueNetworkTableInstance(replacePreferencesNetworkTable = true)
 public final class PersistedConfigurationTest {
   private static final double EPSILON = 0.001;
 
   /** Base class for all nested classes of {@link PersistedConfigurationTest}. */
   @Nested
-  @Execution(ExecutionMode.SAME_THREAD)
+  @Execution(ExecutionMode.SAME_THREAD) // Test updates static state
   abstract class PreferencesRegistryTestCase<T extends Record> {
     private final List<Executable> collectedErrors = new ArrayList<>();
     private final String preferenceName;

--- a/testing/src/main/java/com/team2813/lib2813/testing/junit/jupiter/ProvideUniqueNetworkTableInstanceExtension.java
+++ b/testing/src/main/java/com/team2813/lib2813/testing/junit/jupiter/ProvideUniqueNetworkTableInstanceExtension.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtensionContext.Store;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.platform.commons.support.AnnotationSupport;
 
 /** JUnit Jupiter extension for providing an isolated NetworkTableInstance to tests. */
@@ -56,6 +57,11 @@ final class ProvideUniqueNetworkTableInstanceExtension
 
     ProvideUniqueNetworkTableInstance annotation = ANNOTATION_KEY.get(store);
     if (annotation.replacePreferencesNetworkTable()) {
+      if (ExecutionMode.CONCURRENT == context.getExecutionMode()) {
+        throw new IllegalStateException(
+            "Tests that use ProvideUniqueNetworkTableInstance with replacePreferencesNetworkTable"
+                + " set to true must not use ExecutionMode.CONCURRENT");
+      }
       Preferences.setNetworkTableInstance(ntInstance);
     }
     ntInstance.startLocal();


### PR DESCRIPTION
These changes seem to eliminate the SIGSEGV failures in tests that
use `@ProvideUniqueNetworkTableInstance` and pass
`replacePreferencesNetworkTable=true`.

- Updated `ProvideUniqueNetworkTableInstanceExtension` to drain the
  listener queue before calling `setNetworkTableInstance()` (this
  seems to resolve the `SIGSEGV` issue)
- Call `NetworkTableInstance.startLocal()` (the WPILib Java tests
  call `startServer()`, which seems unnecessary; calling
  `startLocal()` instead seems reasonable)
- Removed `removePreferencesListener()` (it didn't seem to help)
- Annotated `PersistedConfigurationTest` with `@Execution(SAME_THREAD)`
  (this is a no-op, as tests are not run in parallel, but seems like a
  good idea)
- Update `ProvideUniqueNetworkTableInstanceExtension` to fail the test
  if tests are run in parallel and `replacePreferencesNetworkTable` is
  `true`
