### PR TITLE
Extract Camera class

### DIFF
--- a/core/src/test/java/com/team2813/lib2813/preferences/PersistedConfigurationTest.java
+++ b/core/src/test/java/com/team2813/lib2813/preferences/PersistedConfigurationTest.java
@@ -39,6 +39,7 @@ import java.util.Set;
 import java.util.function.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -46,6 +47,7 @@ import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /** Tests for {@link PersistedConfiguration}. */
+@Disabled("WPILib will often crash due to https://github.com/wpilibsuite/allwpilib/issues/8215")
 @ProvideUniqueNetworkTableInstance(replacePreferencesNetworkTable = true)
 public final class PersistedConfigurationTest {
   private static final double EPSILON = 0.001;

--- a/vision/src/main/java/com/team2813/lib2813/vision/Camera.java
+++ b/vision/src/main/java/com/team2813/lib2813/vision/Camera.java
@@ -1,0 +1,86 @@
+/*
+Copyright 2026 Prospect Robotics SWENext Club
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.team2813.lib2813.vision;
+
+import edu.wpi.first.math.geometry.Transform3d;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.photonvision.simulation.SimCameraProperties;
+import org.photonvision.simulation.VisionSystemSim;
+
+/**
+ * A camera on a robot.
+ *
+ * <p>This class can be extended to add additional metadata about the camera.
+ *
+ * @since 2.0.0
+ */
+public class Camera {
+  private final String name;
+  private final Transform3d robotToCamera;
+  protected final Optional<Supplier<SimCameraProperties>> simPropertiesSupplier;
+
+  /**
+   * Adds a camera and associated simulator properties to the multi pose estimator.
+   *
+   * @param name Unique name of the camera. It is recommended for this to describe the camera's
+   *     location (ex: "frontLeft").
+   * @param robotToCamera 3D position of the camera relative to the robot frame.
+   */
+  public Camera(String name, Transform3d robotToCamera) {
+    this(name, robotToCamera, Optional.empty());
+  }
+
+  /**
+   * Adds a camera and associated simulator properties to the multi pose estimator.
+   *
+   * @param name Unique name of the camera. It is recommended for this to describe the camera's
+   *     location (ex: "frontLeft").
+   * @param robotToCamera 3D position of the camera relative to the robot frame.
+   * @param simPropertiesSupplier Factory for providing simulation properties for the camera. This
+   *     is only called when {@link MultiPhotonPoseEstimator#addCamerasToSimulator(VisionSystemSim)}
+   *     is called.
+   */
+  public Camera(
+      String name, Transform3d robotToCamera, Supplier<SimCameraProperties> simPropertiesSupplier) {
+    this(name, robotToCamera, Optional.of(simPropertiesSupplier));
+  }
+
+  private Camera(
+      String name,
+      Transform3d robotToCamera,
+      Optional<Supplier<SimCameraProperties>> simPropertiesSupplier) {
+    Objects.requireNonNull(name, "camera name cannot be null");
+    Objects.requireNonNull(robotToCamera, "robotToCamera cannot be null");
+    if (name.isEmpty()) {
+      throw new IllegalArgumentException("camera name cannot be empty");
+    }
+    this.name = name;
+    this.robotToCamera = robotToCamera;
+    this.simPropertiesSupplier = simPropertiesSupplier;
+  }
+
+  /** Gets the name of the camera. */
+  public final String name() {
+    return name;
+  }
+
+  /** Gets the 3D position of the camera relative to the robot frame. */
+  public final Transform3d robotToCamera() {
+    return robotToCamera;
+  }
+}

--- a/vision/src/main/java/com/team2813/lib2813/vision/Camera.java
+++ b/vision/src/main/java/com/team2813/lib2813/vision/Camera.java
@@ -57,7 +57,11 @@ public class Camera {
    */
   public Camera(
       String name, Transform3d robotToCamera, Supplier<SimCameraProperties> simPropertiesSupplier) {
-    this(name, robotToCamera, Optional.of(simPropertiesSupplier));
+    this(
+        name,
+        robotToCamera,
+        Optional.of(
+            Objects.requireNonNull(simPropertiesSupplier, "simPropertiesSupplier cannot be null")));
   }
 
   private Camera(

--- a/vision/src/main/java/com/team2813/lib2813/vision/MultiPhotonPoseEstimator.java
+++ b/vision/src/main/java/com/team2813/lib2813/vision/MultiPhotonPoseEstimator.java
@@ -25,7 +25,6 @@ import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Rotation3d;
-import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.StructPublisher;
@@ -35,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Supplier;
 import org.photonvision.EstimatedRobotPose;
 import org.photonvision.PhotonCamera;
 import org.photonvision.PhotonPoseEstimator;
@@ -60,15 +58,16 @@ import org.photonvision.simulation.VisionSystemSim;
  * href="https://docs.wpilib.org/en/stable/docs/software/basic-programming/coordinate-system.html#always-blue-origin"
  * target="_top">always specified relative to the blue origin</a>.
  *
+ * @param <C> the type for the camera
  * @since 2.0.0
  */
-public class MultiPhotonPoseEstimator implements AutoCloseable {
-  private final List<PhotonCameraWrapper> cameraWrappers;
+public class MultiPhotonPoseEstimator<C extends Camera> implements AutoCloseable {
+  private final List<PhotonCameraWrapper<C>> cameraWrappers;
   private PhotonPoseEstimator.PoseStrategy poseEstimatorStrategy;
 
   /** A builder for {@code MultiPhotonPoseEstimator}. */
-  public static final class Builder {
-    private final Map<String, CameraConfig> cameraConfigs = new HashMap<>();
+  public static final class Builder<C extends Camera> {
+    private final Map<String, C> cameras = new HashMap<>();
     private final AprilTagFieldLayout aprilTagFieldLayout;
     private final NetworkTableInstance ntInstance;
     private final PhotonPoseEstimator.PoseStrategy poseEstimatorStrategy;
@@ -87,48 +86,20 @@ public class MultiPhotonPoseEstimator implements AutoCloseable {
     /**
      * Adds a camera to the multi pose estimator.
      *
-     * @param name Unique name of the camera. It is recommended for this to describe the camera's
-     *     location (ex: "frontLeft").
-     * @param transform 3D position of the camera relative to the robot frame.
+     * @param camera The camera. Must have a unique name.
      * @return Builder instance.
      */
-    public Builder addCamera(String name, Transform3d transform) {
-      return addCamera(name, transform, Optional.empty());
-    }
-
-    /**
-     * Adds a camera and associated simulator properties to the multi pose estimator.
-     *
-     * @param name Unique name of the camera. It is recommended for this to describe the camera's
-     *     location (ex: "frontLeft").
-     * @param transform 3D position of the camera relative to the robot frame.
-     * @param simulationPropertiesSupplier Factory for providing simulation properties for the
-     *     camera. This is only called when {@link #addCamerasToSimulator(VisionSystemSim)} is
-     *     called.
-     * @return Builder instance.
-     */
-    public Builder addCamera(
-        String name,
-        Transform3d transform,
-        Supplier<SimCameraProperties> simulationPropertiesSupplier) {
-      return addCamera(name, transform, Optional.of(simulationPropertiesSupplier));
-    }
-
-    private Builder addCamera(
-        String name,
-        Transform3d transform,
-        Optional<Supplier<SimCameraProperties>> simPropertiesSupplier) {
-      Objects.requireNonNull(name, "camera name cannot be null");
-      Objects.requireNonNull(transform, "transform cannot be null");
-      if (cameraConfigs.put(name, new CameraConfig(transform, simPropertiesSupplier)) != null) {
-        throw new IllegalArgumentException(String.format("Already a camera with name '%s'", name));
+    public Builder<C> addCamera(C camera) {
+      if (cameras.put(camera.name(), camera) != null) {
+        throw new IllegalArgumentException(
+            String.format("Already a camera with name '%s'", camera.name()));
       }
       return this;
     }
 
     /** Builds a configured MultiPhotonPoseEstimator. */
-    public MultiPhotonPoseEstimator build() {
-      return new MultiPhotonPoseEstimator(this);
+    public MultiPhotonPoseEstimator<C> build() {
+      return new MultiPhotonPoseEstimator<>(this);
     }
   }
 
@@ -141,16 +112,39 @@ public class MultiPhotonPoseEstimator implements AutoCloseable {
    *     locations.
    * @param poseEstimatorStrategy Posing strategy (for instance, multi tag PnP, closest to camera
    *     tag, etc.)
+   * @param cameraType The type for the camera.
    */
-  public static Builder builder(
+  public static <C extends Camera> Builder<C> builder(
+      NetworkTableInstance ntInstance,
+      AprilTagFieldLayout aprilTagFieldLayout,
+      PhotonPoseEstimator.PoseStrategy poseEstimatorStrategy,
+      Class<C> cameraType) {
+    return new Builder<>(ntInstance, aprilTagFieldLayout, poseEstimatorStrategy);
+  }
+
+  /**
+   * Creates a builder for building {@link MultiPhotonPoseEstimator} instances with a custom Camera
+   * type,
+   *
+   * @param ntInstance Network table instance used to log the pose of AprilTag detections as well as
+   *     pose estimates.
+   * @param aprilTagFieldLayout WPILib field description (dimensions) including AprilTag 3D
+   *     locations.
+   * @param poseEstimatorStrategy Posing strategy (for instance, multi tag PnP, closest to camera
+   *     tag, etc.)
+   */
+  public static Builder<Camera> builder(
       NetworkTableInstance ntInstance,
       AprilTagFieldLayout aprilTagFieldLayout,
       PhotonPoseEstimator.PoseStrategy poseEstimatorStrategy) {
-    return new Builder(ntInstance, aprilTagFieldLayout, poseEstimatorStrategy);
+    return builder(ntInstance, aprilTagFieldLayout, poseEstimatorStrategy, Camera.class);
   }
 
   /**
    * Adds all cameras to a simulated vision system.
+   *
+   * <p>Note that the robot code is responsible for calling {@link VisionSystemSim#update(Pose2d)}
+   * or {@link VisionSystemSim#update(Pose3d)} in {@code simulationPeriodic()}.
    *
    * @param simVisionSystem The simulated visual system.
    */
@@ -159,48 +153,33 @@ public class MultiPhotonPoseEstimator implements AutoCloseable {
     Map<String, SimCameraProperties> cameraNameToSimProperties =
         cameraWrappers.stream()
             .collect(
-                toMap(
-                    wrapper -> wrapper.camera.getName(), PhotonCameraWrapper::createSimProperties));
+                toMap(wrapper -> wrapper.camera.name(), PhotonCameraWrapper::createSimProperties));
 
     // Add cameras to the simulated vision system
     cameraWrappers.forEach(
         wrapper -> {
-          SimCameraProperties cameraProps = cameraNameToSimProperties.get(wrapper.camera.getName());
-          PhotonCameraSim simCamera = new PhotonCameraSim(wrapper.camera(), cameraProps);
+          SimCameraProperties cameraProps = cameraNameToSimProperties.get(wrapper.camera.name());
+          PhotonCameraSim simCamera = new PhotonCameraSim(wrapper.photonCamera, cameraProps);
           simVisionSystem.addCamera(simCamera, wrapper.estimator.getRobotToCameraTransform());
         });
   }
 
   /**
-   * Configuration for a camera that is connected to PhotonVision.
-   *
-   * @param robotToCamera The 3D fixed pose of the camera relative to the robot. Intuitively, this
-   *     field describes where on the robot the camera is mounted.
-   * @param simulationPropertiesSupplier Factory for providing simulation properties for the camera.
-   */
-  private record CameraConfig(
-      Transform3d robotToCamera,
-      Optional<Supplier<SimCameraProperties>> simulationPropertiesSupplier) {}
-
-  /**
    * Wrapper containing a PhotonVision camera, pose estimator and publishers.
    *
-   * @param camera A camera connected to PhotonVision.
+   * @param camera The camera.
+   * @param photonCamera A camera connected to PhotonVision.
    * @param estimator A pose estimator configured for this camera.
-   * @param robotToCamera The 3D fixed pose of the camera relative to the robot. Intuitively, this
-   *     field describes where on the robot the camera is mounted.
-   * @param simPropertiesSupplier Factory for providing simulation properties for the camera.
    * @param robotPosePublisher A publisher reporting PhotonVision pose detections to NetworkTables
    *     during the robot runtime.
    * @param cameraPosePublisher A publisher reporting the position of the camera in field-centric
    *     coordinates. In other words, this is the pose most recently set by {@link @setDrivePose}
    *     with the camera's own robotToCamera pose appended to it.
    */
-  private record PhotonCameraWrapper(
-      PhotonCamera camera,
+  private record PhotonCameraWrapper<C extends Camera>(
+      C camera,
+      PhotonCamera photonCamera,
       PhotonPoseEstimator estimator,
-      Transform3d robotToCamera,
-      Optional<Supplier<SimCameraProperties>> simPropertiesSupplier,
       PhotonVisionPosePublisher robotPosePublisher,
       StructPublisher<Pose3d> cameraPosePublisher)
       implements AutoCloseable {
@@ -211,7 +190,7 @@ public class MultiPhotonPoseEstimator implements AutoCloseable {
      * @param robotPose 3D field-centric (relative to blue origin) pose of the drive train.
      */
     void publishCameraPose(Pose3d robotPose) {
-      cameraPosePublisher.set(robotPose.plus(robotToCamera));
+      cameraPosePublisher.set(robotPose.plus(camera.robotToCamera()));
     }
 
     /**
@@ -222,39 +201,40 @@ public class MultiPhotonPoseEstimator implements AutoCloseable {
      */
     private SimCameraProperties createSimProperties() {
       SimCameraProperties simProperties =
-          simPropertiesSupplier
+          camera
+              .simPropertiesSupplier
               .orElseThrow(
                   () ->
                       new IllegalStateException(
                           String.format(
                               "Must pass Supplier<SimCameraProperties> to addCamera() to use camera"
                                   + " %s in simulation",
-                              camera().getName())))
+                              camera().name())))
               .get();
       if (simProperties == null) {
         throw new NullPointerException(
             String.format(
                 "Supplier<SimCameraProperties> passed to addCamera(\"%s\", ...) cannot provide null"
                     + " values",
-                camera().getName()));
+                camera().name()));
       }
       return simProperties;
     }
 
     @Override
     public void close() {
-      camera.close();
+      photonCamera.close();
       cameraPosePublisher.close();
       // TODO: Update PhotonVisionPosePublisher to support close() and call it here
     }
   }
 
   /** Creates an instance using values from a {@code Builder}. */
-  private MultiPhotonPoseEstimator(Builder builder) {
+  private MultiPhotonPoseEstimator(Builder<C> builder) {
     poseEstimatorStrategy = builder.poseEstimatorStrategy;
     cameraWrappers =
-        builder.cameraConfigs.entrySet().stream()
-            .map(entry -> createCameraWrapperFromConfig(builder, entry.getKey(), entry.getValue()))
+        builder.cameras.values().stream()
+            .map(camera -> createCameraWrapper(builder, camera))
             .collect(toCollection(ArrayList::new));
   }
 
@@ -264,28 +244,23 @@ public class MultiPhotonPoseEstimator implements AutoCloseable {
    *
    * <p>The returned value is used to get pose estimates from the camera.
    */
-  private static PhotonCameraWrapper createCameraWrapperFromConfig(
-      Builder builder, String cameraName, CameraConfig cameraConfig) {
-    PhotonCamera camera = new PhotonCamera(builder.ntInstance, cameraName);
+  private static <C extends Camera> PhotonCameraWrapper<C> createCameraWrapper(
+      Builder<C> builder, C camera) {
+    PhotonCamera photonCamera = new PhotonCamera(builder.ntInstance, camera.name());
     PhotonPoseEstimator estimator =
         new PhotonPoseEstimator(
-            builder.aprilTagFieldLayout, builder.poseEstimatorStrategy, cameraConfig.robotToCamera);
+            builder.aprilTagFieldLayout, builder.poseEstimatorStrategy, camera.robotToCamera());
 
     // Create NetworkTables publishers for 1) the position of the camera relative to the robot and
     // 2) the estimated position provided by the camera.
-    NetworkTable parentTable = getTableForCamera(camera);
+    NetworkTable parentTable = getTableForCamera(photonCamera);
     StructPublisher<Pose3d> cameraPosePublisher =
         parentTable.getStructTopic(CAMERA_POSE_TOPIC, Pose3d.struct).publish();
     var estimatedPosePublisher =
         new PhotonVisionPosePublisher(parentTable, builder.aprilTagFieldLayout);
 
-    return new PhotonCameraWrapper(
-        camera,
-        estimator,
-        cameraConfig.robotToCamera,
-        cameraConfig.simulationPropertiesSupplier,
-        estimatedPosePublisher,
-        cameraPosePublisher);
+    return new PhotonCameraWrapper<>(
+        camera, photonCamera, estimator, estimatedPosePublisher, cameraPosePublisher);
   }
 
   /**
@@ -331,7 +306,7 @@ public class MultiPhotonPoseEstimator implements AutoCloseable {
    */
   public void publishCameraPosesRelativeTo(Pose2d pose) {
     Pose3d pose3d = new Pose3d(pose);
-    for (PhotonCameraWrapper cameraWrapper : cameraWrappers) {
+    for (PhotonCameraWrapper<C> cameraWrapper : cameraWrappers) {
       cameraWrapper.publishCameraPose(pose3d);
     }
   }
@@ -345,7 +320,7 @@ public class MultiPhotonPoseEstimator implements AutoCloseable {
    *     coordinates.
    */
   public void addHeadingData(double timestampSeconds, Rotation2d heading) {
-    for (PhotonCameraWrapper cameraWrapper : cameraWrappers) {
+    for (PhotonCameraWrapper<C> cameraWrapper : cameraWrappers) {
       cameraWrapper.estimator.addHeadingData(timestampSeconds, heading);
     }
   }
@@ -359,7 +334,7 @@ public class MultiPhotonPoseEstimator implements AutoCloseable {
    *     coordinates.
    */
   public void addHeadingData(double timestampSeconds, Rotation3d heading) {
-    for (PhotonCameraWrapper cameraWrapper : cameraWrappers) {
+    for (PhotonCameraWrapper<C> cameraWrapper : cameraWrappers) {
       cameraWrapper.estimator.addHeadingData(timestampSeconds, heading);
     }
   }
@@ -373,7 +348,7 @@ public class MultiPhotonPoseEstimator implements AutoCloseable {
    *     coordinates.
    */
   public void resetHeadingData(double timestampSeconds, Rotation2d heading) {
-    for (PhotonCameraWrapper cameraWrapper : cameraWrappers) {
+    for (PhotonCameraWrapper<C> cameraWrapper : cameraWrappers) {
       cameraWrapper.estimator.resetHeadingData(timestampSeconds, heading);
     }
   }
@@ -381,7 +356,7 @@ public class MultiPhotonPoseEstimator implements AutoCloseable {
   public void resetHeadingData(double timestampSeconds, Rotation3d heading) {
     // TODO: Use PhotonPoseEstimator.resetHeadingData(double, Rotation2d) once we use a version of
     // PhotonVision that includes it (see  https://github.com/PhotonVision/photonvision/pull/2013).
-    for (PhotonCameraWrapper cameraWrapper : cameraWrappers) {
+    for (PhotonCameraWrapper<C> cameraWrapper : cameraWrappers) {
       cameraWrapper.estimator.resetHeadingData(timestampSeconds, heading.toRotation2d());
       cameraWrapper.estimator.addHeadingData(timestampSeconds, heading);
     }
@@ -395,15 +370,15 @@ public class MultiPhotonPoseEstimator implements AutoCloseable {
    *
    * @param poseEstimateConsumer Functional interface for consuming computed pose estimates.
    */
-  public void processAllUnreadResults(PoseEstimateConsumer poseEstimateConsumer) {
-    for (PhotonCameraWrapper cameraWrapper : cameraWrappers) {
+  public void processAllUnreadResults(PoseEstimateConsumer<C> poseEstimateConsumer) {
+    for (PhotonCameraWrapper<C> cameraWrapper : cameraWrappers) {
       List<EstimatedRobotPose> poses =
-          cameraWrapper.camera.getAllUnreadResults().stream()
+          cameraWrapper.photonCamera.getAllUnreadResults().stream()
               .map(cameraWrapper.estimator::update) // PhotonPipelineResult -> EstimatedRobotPose
               .flatMap(Optional::stream) // Convert Stream<Optional<P>> -> Stream<P>
               .toList();
 
-      poses.forEach(poseEstimateConsumer::addEstimatedRobotPose);
+      poses.forEach(pose -> poseEstimateConsumer.addEstimatedRobotPose(pose, cameraWrapper.camera));
       cameraWrapper.robotPosePublisher.publish(poses);
     }
   }

--- a/vision/src/main/java/com/team2813/lib2813/vision/MultiPhotonPoseEstimator.java
+++ b/vision/src/main/java/com/team2813/lib2813/vision/MultiPhotonPoseEstimator.java
@@ -90,6 +90,7 @@ public class MultiPhotonPoseEstimator<C extends Camera> implements AutoCloseable
      * @return Builder instance.
      */
     public Builder<C> addCamera(C camera) {
+      Objects.requireNonNull(camera, "camera cannot be null");
       if (cameras.put(camera.name(), camera) != null) {
         throw new IllegalArgumentException(
             String.format("Already a camera with name '%s'", camera.name()));

--- a/vision/src/main/java/com/team2813/lib2813/vision/PoseEstimateConsumer.java
+++ b/vision/src/main/java/com/team2813/lib2813/vision/PoseEstimateConsumer.java
@@ -20,14 +20,16 @@ import org.photonvision.EstimatedRobotPose;
 /**
  * Represents an operation that accepts estimated robot positions.
  *
+ * @param <C> the type for the camera
  * @since 2.0.0
  */
 @FunctionalInterface
-public interface PoseEstimateConsumer {
+public interface PoseEstimateConsumer<C extends Camera> {
   /**
    * Performs an operation on the given estimated robot positions.
    *
-   * @param estimatedPose The estimated robot positions.
+   * @param estimatedPose The estimated robot position.
+   * @param camera The camera.
    */
-  void addEstimatedRobotPose(EstimatedRobotPose estimatedPose);
+  void addEstimatedRobotPose(EstimatedRobotPose estimatedPose, C camera);
 }

--- a/vision/src/test/java/com/team2813/lib2813/vision/MultiPhotonPoseEstimatorTest.java
+++ b/vision/src/test/java/com/team2813/lib2813/vision/MultiPhotonPoseEstimatorTest.java
@@ -48,12 +48,14 @@ class MultiPhotonPoseEstimatorTest {
           0.1708140348,
           new Rotation3d(0, -0.1745329252, -0.5235987756));
 
+  private static final Camera FRONT_CAMERA = new Camera("front", FRONT_CAMERA_TRANSFORM);
+
   @ParameterizedTest
   @EnumSource(value = PoseStrategy.class)
   void getPrimaryStrategy(PoseStrategy poseStrategy, NetworkTableInstance ntInstance) {
     try (var estimator =
-        new MultiPhotonPoseEstimator.Builder(ntInstance, createFieldLayout(), poseStrategy)
-            .addCamera("front", FRONT_CAMERA_TRANSFORM)
+        MultiPhotonPoseEstimator.builder(ntInstance, createFieldLayout(), poseStrategy)
+            .addCamera(FRONT_CAMERA)
             .build()) {
       assertThat(estimator.getPrimaryStrategy()).isEqualTo(poseStrategy);
     }


### PR DESCRIPTION
This simplifies `MultiPhotonPoseEstimator.Builder`. It also allows users to create constant fields for each camera (or different cameras for different drivetrains).

The `Camera` is passed to the callback that the user provides to `processAllUnreadResults()`. The `Camera` class can be subclassed, to allow teams to add additional data about the camera (for instance, you could provide a multiplier to apply to the standard deviation so that you could give a higher weight to some cameras).
