### PR TITLE
Add a task that creates a tar.gz of the javadoc

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -16,4 +16,7 @@ Before publishing to Maven Central, consider publishing to Maven Local.
 9. Decrypt `lib2813-maven-publishing.tar.gz.gpg`
 10. Copy the last five lines of the decrypted file to your personal `gradle.properties` file
 11. Run `./gradlew publishToMavenCentral`
-12. Celebrate!
+12. Generate Javadoc by running `./gradlew archiveJavadoc`
+13. Copy `build/docs/javadoc/javadoc.tar.gz` to the web site and extract it
+14. Update the 'latest' symlink to point to the latest javadoc
+15. Celebrate!

--- a/build.gradle
+++ b/build.gradle
@@ -26,3 +26,31 @@ allprojects {
         }
     }
 }
+
+tasks.register('archiveJavadoc', Tar) {
+    archiveFileName = 'javadoc.tar.gz'
+    compression = Compression.GZIP
+    destinationDirectory = layout.buildDirectory.dir("docs/javadoc")
+
+    from(tasks.named('generateJavadocIndex'))
+
+    subprojects.forEach { sub ->
+        sub.tasks.withType(Javadoc).configureEach { javadocTask ->
+            from(javadocTask.destinationDir) {
+                into sub.name
+            }
+        }
+    }
+}
+
+tasks.register('generateJavadocIndex', Copy) {
+    from 'site/javadoc/latest'
+    include 'index.j2.html'
+    into layout.buildDirectory.dir("docs/javadoc")
+
+    // Rename the file during the copy process
+    rename { 'index.html' }
+
+    // This performs the variable substitution
+    expand([version: gradle.lib_version])
+}

--- a/buildSrc/src/main/groovy/publishing-conventions.gradle
+++ b/buildSrc/src/main/groovy/publishing-conventions.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'com.team2813.lib2813'
-version = "2.0.0"
+version = gradle.lib_version
 
 mavenPublishing {
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,5 +8,6 @@
  */
 
 rootProject.name = 'lib2813'
+gradle.ext.lib_version = "2.0.0"
 include 'core', 'limelight', 'vision', 'testing'
 include 'vendor:ctre', 'vendor:rev'

--- a/site/javadoc/latest/index.j2.html
+++ b/site/javadoc/latest/index.j2.html
@@ -1,0 +1,28 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>lib2813 2.0.0 Javadoc</title>
+  <link rel="stylesheet" href="https://cdn.simplecss.org/simple.min.css">
+  <link rel="stylesheet" href="../stylesheet.css">
+</head>
+<body>
+  <header>
+    <h1>lib2813 {{ version }} Javadoc</h1>
+  </header>
+  <main>
+    <ul>
+      <li><a href="core/">core</a></li>
+      <li><a href="limelight/">limelight</a></li>
+      <li><a href="testing/">testing</a></li>
+      <li><a href="vendor-ctre/">vendor-ctre</a></li>
+      <li><a href="vendor-rev/">vendor-rev</a></li>
+      <li><a href="vision"/>vision</a></li>
+    </ul>
+  </main>
+  <footer>
+    <p>Copyright 2023-2026 Prospect Robotics SWENext Club</p>
+  </footer>
+</body>
+</html>

--- a/site/javadoc/stylesheet.css
+++ b/site/javadoc/stylesheet.css
@@ -1,0 +1,6 @@
+body > header {
+  --accent-bg: #4D7A97;
+}
+:root {
+  --accent: #4D7A97;
+}


### PR DESCRIPTION
This will make it easier to copy new Javadoc to the website for future releases.